### PR TITLE
[libcommhistory] Add contactName role to eventmodel. Contributes to JB#56694

### DIFF
--- a/src/eventmodel.cpp
+++ b/src/eventmodel.cpp
@@ -86,6 +86,7 @@ QHash<int, QByteArray> EventModel::roleNames() const
     roles[SubjectRole] = "subject";
     roles[AccountRole] = "account";
     roles[DateAndAccountGroupingRole] = "dateAndAccountGrouping";
+    roles[ContactNameRole] = "contactName";
     return roles;
 }
 
@@ -298,6 +299,9 @@ QVariant EventModel::data(const QModelIndex &index, int role) const
         case DateAndAccountGroupingRole: {
             return event.dateAndAccountGrouping();
         }
+        case ContactNameRole:
+            return QVariant::fromValue(event.contactName());
+            break;
         default:
             break;
     }

--- a/src/eventmodel.h
+++ b/src/eventmodel.h
@@ -114,6 +114,7 @@ public:
         SubjectRole,
         AccountRole,
         DateAndAccountGroupingRole,
+        ContactNameRole,
         BaseRole = Qt::UserRole + 1000,
     };
 


### PR DESCRIPTION
This role may be needed if a developer wants to implement a call history search.