### PR TITLE
[commhistory] Add a filter property to events.

### DIFF
--- a/declarative/src/callproxymodel.h
+++ b/declarative/src/callproxymodel.h
@@ -44,6 +44,7 @@ class CallProxyModel : public CommHistory::CallModel, public QQmlParserStatus
     Q_ENUMS(EventDirection)
     Q_ENUMS(EventStatus)
     Q_ENUMS(EventReadStatus)
+    Q_ENUMS(EventIncomingStatus)
     Q_ENUMS(GroupBy)
 
     Q_PROPERTY(GroupBy groupBy READ groupBy WRITE setGroupBy NOTIFY groupByChanged)
@@ -89,6 +90,13 @@ public:
         UnknownReadStatus = CommHistory::Event::UnknownReadStatus,
         ReadStatusRead = CommHistory::Event::ReadStatusRead,
         ReadStatusDeleted = CommHistory::Event::ReadStatusDeleted
+    };
+
+    enum EventIncomingStatus {
+        Received = CommHistory::Event::Received,
+        NotAnswered = CommHistory::Event::NotAnswered,
+        Ignored = CommHistory::Event::Ignored,
+        Rejected = CommHistory::Event::Rejected
     };
 
     enum GroupBy {

--- a/rpm/libcommhistory-qt5.spec
+++ b/rpm/libcommhistory-qt5.spec
@@ -1,6 +1,6 @@
 Name:       libcommhistory-qt5
 Summary:    Communications event history database API
-Version:    1.12.0
+Version:    1.12.6
 Release:    1
 License:    LGPLv2
 URL:        https://github.com/sailfishos/libcommhistory

--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -272,8 +272,8 @@ int CallModelPrivate::calculateEventCount(EventTreeItem *item)
                 // the index number 0 is the same item as the top level
                 // one
                 for (int i = 1; i < item->childCount(); i++) {
-                    if (item->child(i - 1)->event().isMissedCall()
-                            && item->child(i)->event().isMissedCall()) {
+                    if (item->event().incomingStatus()
+                        == item->child(i)->event().incomingStatus()) {
                         count++;
                     } else {
                         break;
@@ -515,7 +515,7 @@ void CallModelPrivate::insertEvent(Event event)
 
                 const int groupEventCount(matchingItem->event().eventCount());
                 const bool increaseEventCount(matchingItem->event().direction() == event.direction() &&
-                                              matchingItem->event().isMissedCall() == event.isMissedCall());
+                                              matchingItem->event().incomingStatus() == event.incomingStatus());
 
                 matchingItem->prependChild(new EventTreeItem(event, matchingItem));
                 matchingItem->setEvent(event);
@@ -889,7 +889,7 @@ void CallModelPrivate::recipientsUpdated(const QSet<Recipient> &recipients, bool
 
                 const int groupEventCount(matchingItem->event().eventCount());
                 const bool increaseEventCount(matchingItem->event().direction() == event.direction() &&
-                                              matchingItem->event().isMissedCall() == event.isMissedCall());
+                                              matchingItem->event().incomingStatus() == event.incomingStatus());
 
                 int newChildIndex = 0;
                 for (; newChildIndex < matchingItem->childCount(); ++newChildIndex) {

--- a/src/event.h
+++ b/src/event.h
@@ -110,6 +110,14 @@ public:
         ReadStatusDeleted = 2
     };
 
+    enum EventIncomingStatus {
+        Received = 0,
+        NotAnswered,  // Set the IsMissedCall property
+        Ignored,      // Set the IsMissedCall property
+        Rejected      // Set the IsMissedCall property
+    };
+    Q_ENUM(EventIncomingStatus)
+
     enum Property {
         Id = 0,        // always valid
         Type,          // always valid
@@ -250,6 +258,7 @@ public:
     int bytesReceived() const;
     QString localUid() const;
     QString dateAndAccountGrouping() const;
+    EventIncomingStatus incomingStatus() const;
 
     const RecipientList &recipients() const;
     RecipientList contactRecipients() const;
@@ -341,6 +350,7 @@ public:
     void setMessageToken(const QString &token);
     void setMmsId(const QString &id);
     void setLastModified(const QDateTime &modified);
+    void setIncomingStatus(EventIncomingStatus status);
 
     /*!
      * \brief Sets the value of how many similar call events are represented by the current event.

--- a/src/eventmodel.cpp
+++ b/src/eventmodel.cpp
@@ -89,6 +89,7 @@ QHash<int, QByteArray> EventModel::roleNames() const
     roles[FromVCardLabelRole] = "fromVCardLabel";
     roles[ReadStatusRole] = "readStatus";
     roles[SubscriberIdentityRole] = "subscriberIdentity";
+    roles[IncomingStatusRole] = "incomingStatus";
 
     return roles;
 }
@@ -346,6 +347,8 @@ QVariant EventModel::data(const QModelIndex &index, int role) const
         return QVariant::fromValue((int)event.readStatus());
     case SubscriberIdentityRole:
         return event.subscriberIdentity();
+    case IncomingStatusRole:
+        return event.incomingStatus();
     default:
         DEBUG() << Q_FUNC_INFO << ": invalid role??" << role;
         return QVariant();

--- a/src/eventmodel.h
+++ b/src/eventmodel.h
@@ -110,7 +110,8 @@ public:
         FromVCardFileNameRole,
         FromVCardLabelRole,
         ReadStatusRole,
-        SubscriberIdentityRole
+        SubscriberIdentityRole,
+        IncomingStatusRole
     };
 
     /*!


### PR DESCRIPTION
Since oFono has filtering capabilities,
expose an enum for events that can
represent these capabilities.

Adding such property allow oFono filter
plugins to expose to the user their
activities.

It is done by storing an additional
extra property for events and it provides
getters and setters for it.

@pvuorela , when you will have time, may we discuss of the possibility to add this new API to the comm history ? If you want to see it in action, you can give a look to https://github.com/dcaliste/sailfish-voicecall-filter (which provides an oFono plugin to filter incoming calls and a user daemon that dialogs with the oFono plugin via D-Bus and applies a simple filtering rule from DConf lists of ignored or blocked numbers). To get a feedback in the UI, you can add the following lines in `/usr/share/voicecall-ui-jolla/common/CallDirectionIcon.qml` (in the icon entry):
```
            } else if (call.filterType !== CommCallModel.NoFilter) {
                return "image://theme/icon-s-blocked"
```

The rational to add such enum in the comm history, is that contrary to an MDM filter plugin (which should stay silent), the user would like to monitor when calls were blocked or ignored (at least I do). And the logical place to look at is the call history. Doing it like in this PR via an extra property of Event won't affect existing API of course and don't require any change on the database layout. So it's quite light weight. As for the changes in the UI (the blocked icon even already exists !).