### PR TITLE
[libcommhistory] Remove unneeded and incorrect service name references. JB#62154

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -26,7 +26,6 @@
 namespace CommHistory {
 
 
-#define COMM_HISTORY_SERVICE_NAME  QLatin1String("com.nokia.commhistory")
 #define COMM_HISTORY_INTERFACE     QLatin1String("com.nokia.commhistory")
 #define COMM_HISTORY_OBJECT_PATH   QLatin1String("/CommHistoryModel")
 

--- a/src/eventmodel_p.cpp
+++ b/src/eventmodel_p.cpp
@@ -90,13 +90,13 @@ EventModelPrivate::EventModelPrivate(EventModel *model)
 
     // listen to dbus signals
     QDBusConnection::sessionBus().connect(
-        QString(), QString(), COMM_HISTORY_SERVICE_NAME, EVENTS_ADDED_SIGNAL,
+        QString(), QString(), COMM_HISTORY_INTERFACE, EVENTS_ADDED_SIGNAL,
         this, SLOT(eventsAddedSlot(const QList<CommHistory::Event> &)));
     QDBusConnection::sessionBus().connect(
-        QString(), QString(), COMM_HISTORY_SERVICE_NAME, EVENTS_UPDATED_SIGNAL,
+        QString(), QString(), COMM_HISTORY_INTERFACE, EVENTS_UPDATED_SIGNAL,
         this, SLOT(eventsUpdatedSlot(const QList<CommHistory::Event> &)));
     QDBusConnection::sessionBus().connect(
-        QString(), QString(), COMM_HISTORY_SERVICE_NAME, EVENT_DELETED_SIGNAL,
+        QString(), QString(), COMM_HISTORY_INTERFACE, EVENT_DELETED_SIGNAL,
         this, SLOT(eventDeletedSlot(int)));
 
     eventRootItem = new EventTreeItem(Event());

--- a/src/groupmanager.cpp
+++ b/src/groupmanager.cpp
@@ -149,35 +149,35 @@ GroupManagerPrivate::GroupManagerPrivate(GroupManager *manager)
     QDBusConnection::sessionBus().connect(
         QString(),
         QString(),
-        COMM_HISTORY_SERVICE_NAME,
+        COMM_HISTORY_INTERFACE,
         EVENTS_ADDED_SIGNAL,
         this,
         SLOT(eventsAddedSlot(const QList<CommHistory::Event> &)));
     QDBusConnection::sessionBus().connect(
         QString(),
         QString(),
-        COMM_HISTORY_SERVICE_NAME,
+        COMM_HISTORY_INTERFACE,
         GROUPS_ADDED_SIGNAL,
         this,
         SLOT(groupsAddedSlot(const QList<CommHistory::Group> &)));
     QDBusConnection::sessionBus().connect(
         QString(),
         QString(),
-        COMM_HISTORY_SERVICE_NAME,
+        COMM_HISTORY_INTERFACE,
         GROUPS_UPDATED_SIGNAL,
         this,
         SLOT(groupsUpdatedSlot(const QList<int> &)));
     QDBusConnection::sessionBus().connect(
         QString(),
         QString(),
-        COMM_HISTORY_SERVICE_NAME,
+        COMM_HISTORY_INTERFACE,
         GROUPS_UPDATED_FULL_SIGNAL,
         this,
         SLOT(groupsUpdatedFullSlot(const QList<CommHistory::Group> &)));
     QDBusConnection::sessionBus().connect(
         QString(),
         QString(),
-        COMM_HISTORY_SERVICE_NAME,
+        COMM_HISTORY_INTERFACE,
         GROUPS_DELETED_SIGNAL,
         this,
         SLOT(groupsDeletedSlot(const QList<int> &)));


### PR DESCRIPTION
Commhistoryd is having its own service name which is not this. There should be nothing using it generally. A few places were mistaking service and interface names, though the actual strings are the same.

Spotted while checking @dcaliste's dbus PRs. 