### PR TITLE
Fix unstable unit test. JB#57536

### DIFF
--- a/src/contactlistener.cpp
+++ b/src/contactlistener.cpp
@@ -140,10 +140,12 @@ void ContactListenerPrivate::retryFinished()
     retryRecipients.clear();
 }
 
-static bool recipientMatchesDetails(const Recipient &recipient, const QList<Recipient> &addresses, const QList<Recipient::PhoneNumberMatchDetails> &phoneNumbers)
+static bool recipientMatchesDetails(const Recipient &recipient, const QList<Recipient> &addresses,
+                                    const QList<Recipient::PhoneNumberMatchDetails> &phoneNumbers)
 {
     if (recipient.isPhoneNumber()) {
-        for (QList<Recipient::PhoneNumberMatchDetails>::const_iterator it = phoneNumbers.begin(), end = phoneNumbers.end(); it != end; ++it) {
+        for (QList<Recipient::PhoneNumberMatchDetails>::const_iterator it = phoneNumbers.begin(), end = phoneNumbers.end();
+             it != end; ++it) {
             if (recipient.matchesPhoneNumber(*it))
                 return true;
         }
@@ -162,13 +164,15 @@ void ContactListenerPrivate::itemUpdated(SeasideCache::CacheItem *item)
     Q_Q(ContactListener);
 
     // Only aggregate contacts are relevant
-    if (item->contact.collectionId() != SeasideCache::aggregateCollectionId())
+    if (item->contact.collectionId() != SeasideCache::aggregateCollectionId()) {
         return;
+    }
 
     // Make a list of Recipient from the contacts addresses to compare against
     QList<Recipient> addresses;
     foreach (const QContactOnlineAccount &account, item->contact.details<QContactOnlineAccount>()) {
-        addresses.append(Recipient(account.value<QString>(QContactOnlineAccount__FieldAccountPath), account.accountUri()));
+        addresses.append(Recipient(account.value<QString>(QContactOnlineAccount__FieldAccountPath),
+                                   account.accountUri()));
     }
 
     QList<Recipient::PhoneNumberMatchDetails> phoneNumbers;

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -77,7 +77,8 @@ QContactManager *manager()
     return manager;
 }
 
-QContact createTestContact(const QString &name, const QString &remoteUid, const QString &localUid, const QString &contactUri)
+QContact createTestContact(const QString &name, const QString &remoteUid, const QString &localUid,
+                           const QString &contactUri)
 {
     QContact contact;
 
@@ -243,8 +244,8 @@ int addTestEvent(EventModel &model,
         event.setRecipients(Recipient(account, remoteUid));
     }
     event.setFreeText(text);
-    event.setIsDraft( isDraft );
-    event.setIsMissedCall( isMissedCall );
+    event.setIsDraft(isDraft);
+    event.setIsMissedCall(isMissedCall);
     event.setMessageToken(messageToken);
     event.setSubscriberIdentity(subscriberIdentity);
     if (model.addEvent(event, toModelOnly)) {
@@ -279,14 +280,17 @@ void addTestGroup(Group& grp, QString localUid, QString remoteUid)
 
 QContactId localContactForAggregate(const QContactId &aggregateId)
 {
-    foreach (const QContactRelationship &relationship, manager()->relationships(QContactRelationship::Aggregates(), aggregateId, QContactRelationship::First)) {
+    foreach (const QContactRelationship &relationship,
+             manager()->relationships(QContactRelationship::Aggregates(),
+                                      aggregateId, QContactRelationship::First)) {
         return relationship.second();
     }
     qWarning() << "error finding local contact for aggregate:" << aggregateId.localId();
     return QContactId();
 }
 
-int addTestContact(const QString &name, const QString &remoteUid, const QString &localUid, ContactChangeListener *listener)
+int addTestContact(const QString &name, const QString &remoteUid, const QString &localUid,
+                   ContactChangeListener *listener)
 {
     QString contactUri = QString("<testcontact:%1>").arg(contactNumber++);
 
@@ -300,7 +304,10 @@ int addTestContact(const QString &name, const QString &remoteUid, const QString 
     }
 
     int retValue = -1;
-    foreach (const QContactRelationship &relationship, manager()->relationships(QContactRelationship::Aggregates(), contact.id(), QContactRelationship::Second)) {
+    foreach (const QContactRelationship &relationship,
+             manager()->relationships(QContactRelationship::Aggregates(),
+                                      contact.id(),
+                                      QContactRelationship::Second)) {
         const QContactId &aggId = relationship.first();
         addedContactIds.insert(aggId);
         retValue = internalContactId(aggId);
@@ -609,7 +616,8 @@ void summarizeResults(const QString &className, QList<int> &times, QFile *logFil
     }
 
     const float mean = sum / (float)iterations;
-    qDebug("##### Mean: %.1f; Median: %.1f; Min: %d; Max: %d; Test time: %dsec", mean, median, times[0], times[iterations-1], testSecs);
+    qDebug("##### Mean: %.1f; Median: %.1f; Min: %d; Max: %d; Test time: %dsec", mean, median,
+           times[0], times[iterations-1], testSecs);
 
     if (logFile) {
         QString descriptor(className + "::" + QTest::currentTestFunction());
@@ -622,7 +630,8 @@ void summarizeResults(const QString &className, QList<int> &times, QFile *logFil
             << "\n"
             << timeList.join(" ")
             << "\n"
-            << "Median average: " << (int)median << " ms. Min: " << times[0] << "ms. Max: " << times[iterations-1] << " ms. Test time: ";
+            << "Median average: " << (int)median << " ms. Min: " << times[0] << "ms. Max: " << times[iterations-1]
+            << " ms. Test time: ";
         if (testSecs > 3600)
             out << (testSecs / 3600) << "h ";
         if (testSecs > 60)

--- a/tests/ut_eventmodel/eventmodeltest.cpp
+++ b/tests/ut_eventmodel/eventmodeltest.cpp
@@ -1444,9 +1444,9 @@ void EventModelTest::testContactMatching()
     QCOMPARE(event.contactName(), QString("Moderately Bad"));
 
     // After the contacts are removed, the events resolve to nothing
-    deleteTestContact(contactId1, &contactChangeListener);
-    deleteTestContact(contactId, &contactChangeListener);
-    deleteTestContact(replacementContactId, &contactChangeListener);
+    deleteTestContact(contactId1);
+    deleteTestContact(contactId);
+    deleteTestContact(replacementContactId);
 
     QTRY_COMPARE(model.event(model.findEvent(eventId)).contactId(), 0);
     QTRY_COMPARE(model.event(model.findEvent(eventId)).contactName(), QString());


### PR DESCRIPTION
Some cosmetic changes in other commit, the actual fix being 3 lines for removing parameter.

Main commit message

    The deleteTestContact() given a change listener creates an event loop
    and continues processing until the change happens.
    
    On the other side SeasideCache was hitting idle processing
    to remove instances for contacts being in m_expiredContacts,
    and when reaching SeasideCache::contactsRemoved() them being already
    gone, and thus change listener not getting a callback with the instance.
    And that, on its part, confusing libcommhistory side.
    
    It's up for consideration how much SeasideCache should cope with
    extra event loops, but those are rare, likely a bad idea, and regardless
    of it, in the unit test there shouldn't be reason for waiting individual
    contact deletions to finish before proceeding to the next one.
    The QTRY_COMPARE() should ensure that it ends up with expected state.

