### PR TITLE
[libcommhistory] Clean up commonutils and add method to match phone numbers. JB#62531

### DIFF
--- a/declarative/declarative.pro
+++ b/declarative/declarative.pro
@@ -5,7 +5,7 @@ TARGET = commhistory-declarative
 PLUGIN_IMPORT_PATH = org/nemomobile/commhistory
 VERSION = $$PROJECT_VERSION
 
-INCLUDEPATH += ../src 
+INCLUDEPATH += ../src
 
 SOURCES += src/plugin.cpp \
     src/callproxymodel.cpp \
@@ -28,7 +28,7 @@ HEADERS += src/constants.h \
     src/draftevent.h
 
 TEMPLATE = lib
-CONFIG += qt plugin hide_symbols 
+CONFIG += qt plugin hide_symbols
 QT += qml contacts dbus
 QT -= gui
 

--- a/declarative/src/declarativerecipienteventmodel.cpp
+++ b/declarative/src/declarativerecipienteventmodel.cpp
@@ -31,7 +31,7 @@
  */
 
 #include "declarativerecipienteventmodel.h"
-#include "commonutils.h"
+#include "commonutils_p.h"
 
 #include <QQmlInfo>
 

--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -31,7 +31,6 @@
 #include "eventmodel_p.h"
 #include "callmodel.h"
 #include "event.h"
-#include "commonutils.h"
 #include "debug.h"
 
 namespace {

--- a/src/commonutils.cpp
+++ b/src/commonutils.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 
 #include "commonutils.h"
+#include "commonutils_p.h"
 #include "libcommhistoryexport.h"
 
 #include <qtcontacts-extensions.h>
@@ -41,6 +42,10 @@ int phoneNumberMatchLength()
 }
 
 namespace CommHistory {
+LIBCOMMHISTORY_EXPORT bool localUidComparesPhoneNumbers(const QString &localUid)
+{
+    return localUid.startsWith(RING_ACCOUNT);
+}
 
 LIBCOMMHISTORY_EXPORT QString normalizePhoneNumber(const QString &number, bool validate)
 {
@@ -55,68 +60,6 @@ LIBCOMMHISTORY_EXPORT QString normalizePhoneNumber(const QString &number, bool v
 LIBCOMMHISTORY_EXPORT QString minimizePhoneNumber(const QString &number)
 {
     return QtContactsSqliteExtensions::minimizePhoneNumber(number, phoneNumberMatchLength());
-}
-
-LIBCOMMHISTORY_EXPORT bool remoteAddressMatch(const QString &localUid, const QString &uid, const QString &match, bool minimizedComparison)
-{
-    if (localUidComparesPhoneNumbers(localUid)) {
-        QString phone, phoneMatch;
-        if (minimizedComparison) {
-            phone = minimizePhoneNumber(uid);
-            phoneMatch = minimizePhoneNumber(match);
-        } else {
-            phone = normalizePhoneNumber(uid, false);
-            phoneMatch = normalizePhoneNumber(match, false);
-        }
-
-        // If normalization returned an empty number (no digits), compare the input instead
-        if (phone.isEmpty())
-            phone = uid;
-        if (phoneMatch.isEmpty())
-            phoneMatch = match;
-
-        return phoneMatch.compare(phone, Qt::CaseInsensitive) == 0;
-    } else {
-        return match.compare(uid, Qt::CaseInsensitive) == 0;
-    }
-}
-
-LIBCOMMHISTORY_EXPORT bool remoteAddressMatch(const QString &localUid, const QStringList &originalUids, const QStringList &originalMatches, bool minimizedComparison)
-{
-    if (originalUids.size() != originalMatches.size())
-        return false;
-
-    QStringList uids;
-    foreach (QString uid, originalUids) {
-        if (localUidComparesPhoneNumbers(localUid)) {
-            QString number = minimizedComparison ? minimizePhoneNumber(uid) : normalizePhoneNumber(uid, false);
-            if (!number.isEmpty())
-                uid = number;
-        }
-
-        uids.append(uid);
-    }
-
-    QStringList matches;
-    foreach (QString match, originalMatches) {
-        if (localUidComparesPhoneNumbers(localUid)) {
-            QString number = minimizedComparison ? minimizePhoneNumber(match) : normalizePhoneNumber(match, false);
-            if (!number.isEmpty())
-                match = number;
-        }
-
-        matches.append(match);
-    }
-
-    uids.sort(Qt::CaseInsensitive);
-    matches.sort(Qt::CaseInsensitive);
-
-    for (int i = 0; i < uids.size(); i++) {
-        if (uids[i].compare(matches[i], Qt::CaseInsensitive) != 0)
-            return false;
-    }
-
-    return true;
 }
 
 }

--- a/src/commonutils.h
+++ b/src/commonutils.h
@@ -27,18 +27,13 @@
 
 namespace CommHistory {
 
-const QString RING_ACCOUNT = QStringLiteral("/org/freedesktop/Telepathy/Account/ring/tel");
-
 /*!
- * Whether the given localUid needs phone number comparsions
+ * Whether the given localUid needs phone number comparisons
  *
  * \param localUid Local UID
  * \return true if remote UIDs will be compared as phone numbers
  */
-inline bool localUidComparesPhoneNumbers(const QString &localUid)
-{
-    return localUid.startsWith(RING_ACCOUNT);
-}
+bool localUidComparesPhoneNumbers(const QString &localUid);
 
 /*!
  * Validates and normalizes a phone number by removing extra characters:
@@ -60,19 +55,6 @@ QString normalizePhoneNumber(const QString &number, bool validate);
  * \return Last digits of the number.
  */
 QString minimizePhoneNumber(const QString &number);
-
-/*!
- * Compares the two remote ids. In case of phone numbers, last digits
- * are compared.
- *
- * \param localUid Local UID to determine comparison type
- * \param uid First remote id.
- * \param match Second remote id.
- * \param minimizedComparison Compare numbers in minimized form.
- * \return true if addresses match.
- */
-bool remoteAddressMatch(const QString &localUid, const QString &uid, const QString &match, bool minimizedComparison = false);
-bool remoteAddressMatch(const QString &localUid, const QStringList &uids, const QStringList &match, bool minimizedComparison = false);
 
 }
 

--- a/src/commonutils_p.h
+++ b/src/commonutils_p.h
@@ -1,0 +1,8 @@
+#ifndef COMMONUTILS_P_H
+#define COMMONUTILS_P_H
+
+#include <QString>
+
+#define RING_ACCOUNT QString::fromLatin1("/org/freedesktop/Telepathy/Account/ring/tel")
+
+#endif

--- a/src/contactfetcher.cpp
+++ b/src/contactfetcher.cpp
@@ -23,7 +23,6 @@
 #include "contactfetcher.h"
 #include "contactresolver.h"
 
-#include "commonutils.h"
 #include "debug.h"
 
 #include <seasidecache.h>

--- a/src/contactgroup.cpp
+++ b/src/contactgroup.cpp
@@ -22,7 +22,6 @@
 
 #include "contactgroup.h"
 #include "updatesemitter.h"
-#include "commonutils.h"
 #include "databaseio.h"
 #include "debug.h"
 

--- a/src/contactgroupmodel.cpp
+++ b/src/contactgroupmodel.cpp
@@ -27,7 +27,6 @@
 #include "contactgroupmodel.h"
 #include "groupmanager.h"
 #include "contactgroup.h"
-#include "commonutils.h"
 #include "debug.h"
 
 using namespace CommHistory;

--- a/src/contactlistener.cpp
+++ b/src/contactlistener.cpp
@@ -35,7 +35,6 @@
 #include <QContactEmailAddress>
 
 #include "recipient_p.h"
-#include "commonutils.h"
 #include "contactresolver.h"
 #include "debug.h"
 

--- a/src/contactresolver.cpp
+++ b/src/contactresolver.cpp
@@ -25,7 +25,6 @@
 #include <QElapsedTimer>
 
 #include "recipient_p.h"
-#include "commonutils.h"
 #include "debug.h"
 
 #include <seasidecache.h>

--- a/src/databaseio_p.h
+++ b/src/databaseio_p.h
@@ -34,7 +34,6 @@
 #include <QSqlDatabase>
 
 #include "event.h"
-#include "commonutils.h"
 
 namespace CommHistory {
 

--- a/src/eventmodel.cpp
+++ b/src/eventmodel.cpp
@@ -27,7 +27,7 @@
 #include "eventmodel.h"
 #include "eventmodel_p.h"
 #include "adaptor.h"
-#include "commonutils.h"
+#include "commonutils_p.h"
 #include "event.h"
 #include "eventtreeitem.h"
 #include "debug.h"
@@ -293,8 +293,8 @@ QVariant EventModel::data(const QModelIndex &index, int role) const
         return QVariant::fromValue(event.subject());
     case AccountRole: {
         QString localUid = event.localUid();
-        if (localUid.startsWith(CommHistory::RING_ACCOUNT)) {
-            return QVariant::fromValue(CommHistory::RING_ACCOUNT);
+        if (localUid.startsWith(RING_ACCOUNT)) {
+            return QVariant::fromValue(RING_ACCOUNT);
         }
         return QVariant::fromValue(localUid);
     }

--- a/src/groupmanager.cpp
+++ b/src/groupmanager.cpp
@@ -24,7 +24,6 @@
 #include <QtDBus/QtDBus>
 #include <QSqlQuery>
 
-#include "commonutils.h"
 #include "contactresolver.h"
 #include "databaseio.h"
 #include "databaseio_p.h"

--- a/src/groupmodel.cpp
+++ b/src/groupmodel.cpp
@@ -22,7 +22,6 @@
 
 #include <QtDBus/QtDBus>
 
-#include "commonutils.h"
 #include "groupmodel.h"
 #include "groupmodel_p.h"
 #include "eventmodel.h"

--- a/src/recipient.cpp
+++ b/src/recipient.cpp
@@ -24,6 +24,7 @@
 #include "recipient_p.h"
 
 #include "commonutils.h"
+#include "commonutils_p.h"
 
 #include <QSet>
 #include <QHash>
@@ -65,7 +66,7 @@ QPair<QString, QString> makeUidPair(const QString &localUid, const QString &remo
     // If localUid is for phone number, use prefix alone to find the RecipientPrivate
     // this avoids problems with different SIMs etc.
     const bool usesPhoneNumberComparison = CommHistory::localUidComparesPhoneNumbers(localUid);
-    return qMakePair(usesPhoneNumberComparison ? CommHistory::RING_ACCOUNT : localUid,
+    return qMakePair(usesPhoneNumberComparison ? RING_ACCOUNT : localUid,
                      ::minimizeRemoteUid(remoteUid, usesPhoneNumberComparison));
 }
 

--- a/src/recipienteventmodel.cpp
+++ b/src/recipienteventmodel.cpp
@@ -26,6 +26,8 @@
 #include "databaseio_p.h"
 #include "eventmodel_p.h"
 #include "recipienteventmodel_p.h"
+#include "commonutils.h"
+#include "commonutils_p.h"
 
 #include <QSqlQuery>
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -108,6 +108,7 @@ HEADERS += \
            $$PUBLIC_HEADERS \
            commhistorydatabase.h \
            adaptor.h \
+           commonutils_p.h \
            dbus_p.h \
            debug.h \
            eventmodel_p.h \

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -54,7 +54,6 @@
 #include "event.h"
 #include "recipient.h"
 #include "common.h"
-#include "commonutils.h"
 #include "contactlistener.h"
 #include "commhistorydatabasepath.h"
 

--- a/tests/common.h
+++ b/tests/common.h
@@ -24,6 +24,7 @@
 #define COMMON_H
 
 #include "commonutils.h"
+#include "commonutils_p.h"
 #include "eventmodel.h"
 #include "event.h"
 #include "group.h"


### PR DESCRIPTION
Small api break: split the commonutils into semi-public and private part. Removed some parts from being exported externally. Didn't find any use and the header is not having a "qt-like" version, hinting towards not being that public anyway.

Namely remoteAddressMatch() and RING_ACCOUNT are gone. For former I didn't find any usage. The latter should be more internal detail, hopefully on its way out at some point. Additionally its implementation with a QStringLiteral on a header is not a good setup.

On addition there is now phoneNumberMatch() which works like remoteAddressMatch() except not needing the RING_ACCOUNT.

---- 

@dcaliste maybe something like this? Maybe slightly bothers me that there's actually nothing in libcommhistory that was or is using the uid/number matching, but guess it's still better to have it here rather than making other components use qtcontacts-sqlite-extensions if they need libcommhistory but not that much qtcontacts stuff.