### PR TITLE
[libcommhistory] Create a recipient from a phone number.

### DIFF
--- a/declarative/src/declarativerecipienteventmodel.cpp
+++ b/declarative/src/declarativerecipienteventmodel.cpp
@@ -103,9 +103,7 @@ void DeclarativeRecipientEventModel::reload()
     if (m_contactId > 0) {
         setRecipients(m_contactId);
     } else if (!m_remoteUid.isEmpty()) {
-        // Use the generic RING_ACCOUNT because we don't care about which SIM
-        // the call was received on.
-        setRecipients(Recipient(RING_ACCOUNT, m_remoteUid));
+        setRecipients(Recipient::fromPhoneNumber(m_remoteUid));
     }
 
     getEvents();

--- a/src/recipient.cpp
+++ b/src/recipient.cpp
@@ -105,6 +105,11 @@ Recipient::Recipient(const WeakRecipient &weak)
         d = *sharedNullRecipient;
 }
 
+Recipient Recipient::fromPhoneNumber(const QString &number)
+{
+    return Recipient(RING_ACCOUNT, number);
+}
+
 Recipient &Recipient::operator=(const Recipient &o)
 {
     d = o.d;
@@ -405,6 +410,11 @@ RecipientList RecipientList::fromUids(const QString &localUid, const QStringList
     return re;
 }
 
+RecipientList RecipientList::fromPhoneNumbers(const QStringList &phoneNumbers)
+{
+    return RecipientList::fromUids(RING_ACCOUNT, phoneNumbers);
+}
+
 RecipientList RecipientList::fromContact(int contactId)
 {
     return RecipientPrivate::recipientListFromCacheItem(SeasideCache::itemById(contactId, false));
@@ -424,7 +434,7 @@ RecipientList RecipientPrivate::recipientListFromCacheItem(const SeasideCache::C
         }
         foreach (const QContactPhoneNumber &phoneNumber, item->contact.details<QContactPhoneNumber>()) {
             // Match with recipients calling from any SIM
-            re << Recipient(RING_ACCOUNT, phoneNumber.number());
+            re << Recipient::fromPhoneNumber(phoneNumber.number());
         }
     }
     return re;

--- a/src/recipient.h
+++ b/src/recipient.h
@@ -126,6 +126,10 @@ public:
      */
     static PhoneNumberMatchDetails phoneNumberMatchDetails(const QString &s);
 
+    /* Create a Recipient from a given phone number
+     */
+    static Recipient fromPhoneNumber(const QString &number);
+
     /* Represent the current recipient as suitable for phone number matching
      */
     PhoneNumberMatchDetails toPhoneNumberMatchDetails() const;
@@ -145,6 +149,7 @@ public:
     RecipientList(const QList<Recipient> &recipients);
 
     static RecipientList fromUids(const QString &localUid, const QStringList &remoteUids);
+    static RecipientList fromPhoneNumbers(const QStringList &phoneNumbers);
     static RecipientList fromContact(int contactId);
 
     bool isEmpty() const;

--- a/tests/perf_callmodel/callmodelperftest.cpp
+++ b/tests/perf_callmodel/callmodelperftest.cpp
@@ -158,7 +158,7 @@ void CallModelPerfTest::getEvents()
         e.setStartTime(when.addSecs(ei));
         e.setEndTime(when.addSecs(ei));
         e.setLocalUid(RING_ACCOUNT);
-        e.setRecipients(Recipient(RING_ACCOUNT, remoteUids.at(contactIndices.at(qrand() % selected))));
+        e.setRecipients(Recipient::fromPhoneNumber(remoteUids.at(contactIndices.at(qrand() % selected))));
         e.setFreeText("");
         e.setIsDraft(false);
         e.setIsMissedCall(isMissed);

--- a/tests/perf_conversationmodel/conversationmodelperftest.cpp
+++ b/tests/perf_conversationmodel/conversationmodelperftest.cpp
@@ -143,7 +143,7 @@ void ConversationModelPerfTest::getEvents()
     while(gi < contacts) {
         Group grp;
         grp.setLocalUid(RING_ACCOUNT);
-        grp.setRecipients(RecipientList::fromUids(RING_ACCOUNT, QStringList() << remoteUids.at(contactIndices.at(gi))));
+        grp.setRecipients(RecipientList::fromPhoneNumbers(QStringList() << remoteUids.at(contactIndices.at(gi))));
 
         QVERIFY(groupModel.addGroup(grp));
         groupList << grp;
@@ -181,7 +181,7 @@ void ConversationModelPerfTest::getEvents()
         e.setStartTime(when.addSecs(ei));
         e.setEndTime(when.addSecs(ei));
         e.setLocalUid(RING_ACCOUNT);
-        e.setRecipients(Recipient(RING_ACCOUNT, remoteUids.at(index)));
+        e.setRecipients(Recipient::fromPhoneNumber(remoteUids.at(index)));
         e.setFreeText(randomMessage(qrand() % 49 + 1)); // Max 50 words / message
         e.setIsDraft(false);
         e.setIsMissedCall(false);

--- a/tests/perf_groupmodel/groupmodelperftest.cpp
+++ b/tests/perf_groupmodel/groupmodelperftest.cpp
@@ -144,7 +144,7 @@ void GroupModelPerfTest::getGroups()
     while(gi < groups) {
         Group grp;
         grp.setLocalUid(RING_ACCOUNT);
-        grp.setRecipients(RecipientList::fromUids(RING_ACCOUNT, QStringList() << remoteUids.at(contactIndices.at(gi))));
+        grp.setRecipients(RecipientList::fromPhoneNumbers(QStringList() << remoteUids.at(contactIndices.at(gi))));
 
         QVERIFY(addModel.addGroup(grp));
         groupList << grp;

--- a/tests/profile_callmodel/callmodelprofiletest.cpp
+++ b/tests/profile_callmodel/callmodelprofiletest.cpp
@@ -116,7 +116,7 @@ void CallModelProfileTest::prepare()
         e.setStartTime(when.addSecs(ei));
         e.setEndTime(when.addSecs(ei));
         e.setLocalUid(RING_ACCOUNT);
-        e.setRecipients(Recipient(RING_ACCOUNT, remoteUids.at(contactIndices.at(qrand() % selected))));
+        e.setRecipients(Recipient::fromPhoneNumber(remoteUids.at(contactIndices.at(qrand() % selected))));
         e.setFreeText("");
         e.setIsDraft(false);
         e.setIsMissedCall(isMissed);

--- a/tests/profile_conversationmodel/conversationmodelprofiletest.cpp
+++ b/tests/profile_conversationmodel/conversationmodelprofiletest.cpp
@@ -97,7 +97,7 @@ void ConversationModelProfileTest::prepare()
     while(gi < contacts) {
         Group grp;
         grp.setLocalUid(RING_ACCOUNT);
-        grp.setRecipients(RecipientList::fromUids(RING_ACCOUNT, QStringList() << remoteUids.at(contactIndices.at(gi))));
+        grp.setRecipients(RecipientList::fromPhoneNumbers(QStringList() << remoteUids.at(contactIndices.at(gi))));
 
         QVERIFY(groupModel.addGroup(grp));
         groupList << grp;
@@ -134,7 +134,7 @@ void ConversationModelProfileTest::prepare()
         e.setStartTime(when.addSecs(ei));
         e.setEndTime(when.addSecs(ei));
         e.setLocalUid(RING_ACCOUNT);
-        e.setRecipients(Recipient(RING_ACCOUNT, remoteUids.at(index)));
+        e.setRecipients(Recipient::fromPhoneNumber(remoteUids.at(index)));
         e.setFreeText(randomMessage(qrand() % 49 + 1)); // Max 50 words / message
         e.setIsDraft(false);
         e.setIsMissedCall(false);

--- a/tests/profile_groupmodel/groupmodelprofiletest.cpp
+++ b/tests/profile_groupmodel/groupmodelprofiletest.cpp
@@ -96,7 +96,7 @@ void GroupModelProfileTest::prepare()
     while(gi < groups) {
         Group grp;
         grp.setLocalUid(RING_ACCOUNT);
-        grp.setRecipients(RecipientList::fromUids(RING_ACCOUNT, QStringList() << remoteUids.at(contactIndices.at(gi))));
+        grp.setRecipients(RecipientList::fromPhoneNumbers(QStringList() << remoteUids.at(contactIndices.at(gi))));
 
         QVERIFY(addModel.addGroup(grp));
         groupList << grp;

--- a/tests/ut_callmodel/callmodeltest.cpp
+++ b/tests/ut_callmodel/callmodeltest.cpp
@@ -1055,7 +1055,7 @@ void CallModelTest::testMinimizedPhone()
     for (int i = 0; i < model.rowCount(); ++i) {
         Event e = model.event(model.index(i, 0));
         QCOMPARE(e.recipients().count(), 1);
-        QCOMPARE(e.recipients().at(0), Recipient(RING_ACCOUNT, phone00));
+        QCOMPARE(e.recipients().at(0), Recipient::fromPhoneNumber(phone00));
         QCOMPARE(e.recipients().at(0).isContactResolved(), true);
         QCOMPARE(e.recipients().at(0).contactId(), user00id);
         QCOMPARE(e.recipients().at(0).contactName(), user00);
@@ -1068,7 +1068,7 @@ void CallModelTest::testMinimizedPhone()
     for (int i = 0; i < model.rowCount(); ++i) {
         Event e = model.event(model.index(i, 0));
         QCOMPARE(e.recipients().count(), 1);
-        QCOMPARE(e.recipients().at(0), Recipient(RING_ACCOUNT, phone99));
+        QCOMPARE(e.recipients().at(0), Recipient::fromPhoneNumber(phone99));
         QTRY_COMPARE(e.recipients().at(0).contactId(), user99id);
         QCOMPARE(e.recipients().at(0).contactName(), user99);
     }
@@ -1080,7 +1080,7 @@ void CallModelTest::testMinimizedPhone()
     for (int i = 0; i < model.rowCount(); ++i) {
         Event e = model.event(model.index(i, 0));
         QCOMPARE(e.recipients().count(), 1);
-        QCOMPARE(e.recipients().at(0), Recipient(RING_ACCOUNT, phone99));
+        QCOMPARE(e.recipients().at(0), Recipient::fromPhoneNumber(phone99));
         QTRY_COMPARE(e.recipients().at(0).contactId(), 0);
         QCOMPARE(e.recipients().at(0).contactName(), QString());
     }
@@ -1118,13 +1118,13 @@ void CallModelTest::testMinimizedEmpty()
     Event e;
     e = model.event(model.index(0, 0));
     QCOMPARE(e.recipients().count(), 1);
-    QCOMPARE(e.recipients().at(0), Recipient(RING_ACCOUNT, phone2));
+    QCOMPARE(e.recipients().at(0), Recipient::fromPhoneNumber(phone2));
     QCOMPARE(e.recipients().at(0).isContactResolved(), true);
     QCOMPARE(e.recipients().at(0).contactId(), 0);
 
     e = model.event(model.index(1, 0));
     QCOMPARE(e.recipients().count(), 1);
-    QCOMPARE(e.recipients().at(0), Recipient(RING_ACCOUNT, phone1));
+    QCOMPARE(e.recipients().at(0), Recipient::fromPhoneNumber(phone1));
     QCOMPARE(e.recipients().at(0).isContactResolved(), true);
     QCOMPARE(e.recipients().at(0).contactId(), 0);
 }

--- a/tests/ut_eventmodel/eventmodeltest.cpp
+++ b/tests/ut_eventmodel/eventmodeltest.cpp
@@ -397,7 +397,7 @@ void EventModelTest::testDeleteEventVCard()
     event.setStartTime(QDateTime::currentDateTime());
     event.setEndTime(QDateTime::currentDateTime());
     event.setLocalUid(RING_ACCOUNT);
-    event.setRecipients(Recipient(RING_ACCOUNT, "555123456"));
+    event.setRecipients(Recipient::fromPhoneNumber("555123456"));
     event.setFreeText("vcard test");
     event.setFromVCard(VCARD_FILE_1, VCARD_LABEL_1);
 
@@ -504,7 +504,7 @@ void EventModelTest::testDeleteEventMmsParts()
     // test vcard resource deletion
     Event event;
     event.setLocalUid(RING_ACCOUNT);
-    event.setRecipients(Recipient(RING_ACCOUNT, "0506661234"));
+    event.setRecipients(Recipient::fromPhoneNumber("0506661234"));
     event.setType(Event::MMSEvent);
     event.setDirection(Event::Outbound);
     event.setStartTime(QDateTime::currentDateTime());

--- a/tests/ut_groupmodel/groupmodeltest.cpp
+++ b/tests/ut_groupmodel/groupmodeltest.cpp
@@ -977,7 +977,7 @@ void GroupModelTest::resolveContact()
     QStringList uids;
     uids << phoneNumber;
     grp.setLocalUid(RING_ACCOUNT);
-    grp.setRecipients(RecipientList::fromUids(RING_ACCOUNT, uids));
+    grp.setRecipients(RecipientList::fromPhoneNumbers(uids));
 
     int groupCount = groupModel.rowCount();
 
@@ -1224,7 +1224,7 @@ void GroupModelTest::changeRemoteUid()
         Group g = groupModel.group(groupModel.index(i, 0));
         if (g.id() == group.id()) {
             QCOMPARE(g.recipients().size(), 1);
-            QCOMPARE(g.recipients().containsMatch(Recipient(RING_ACCOUNT, oldRemoteUid)), true);
+            QCOMPARE(g.recipients().containsMatch(Recipient::fromPhoneNumber(oldRemoteUid)), true);
             groupsFound++;
         }
     }
@@ -1241,8 +1241,8 @@ void GroupModelTest::changeRemoteUid()
 
     group = groupModel.group(groupModel.index(0, 0));
     QCOMPARE(group.recipients().size(), 2);
-    QCOMPARE(group.recipients().containsMatch(Recipient(RING_ACCOUNT, newRemoteUid)), true);
-    QCOMPARE(group.recipients().containsMatch(Recipient(RING_ACCOUNT, oldRemoteUid)), true);
+    QCOMPARE(group.recipients().containsMatch(Recipient::fromPhoneNumber(newRemoteUid)), true);
+    QCOMPARE(group.recipients().containsMatch(Recipient::fromPhoneNumber(oldRemoteUid)), true);
 
     modelReady.clear();
     QVERIFY(groupModel.getGroups());
@@ -1251,9 +1251,9 @@ void GroupModelTest::changeRemoteUid()
     group = groupModel.group(groupModel.index(0, 0));
     QEXPECT_FAIL("", "Group modifications are not currently stored to database", Continue);
     QCOMPARE(group.recipients().size(), 2);
-    QCOMPARE(group.recipients().containsMatch(Recipient(RING_ACCOUNT, oldRemoteUid)), true);
+    QCOMPARE(group.recipients().containsMatch(Recipient::fromPhoneNumber(oldRemoteUid)), true);
     QEXPECT_FAIL("", "Group modifications are not currently stored to database", Continue);
-    QCOMPARE(group.recipients().containsMatch(Recipient(RING_ACCOUNT, newRemoteUid)), true);
+    QCOMPARE(group.recipients().containsMatch(Recipient::fromPhoneNumber(newRemoteUid)), true);
 
     deleteTestContact(oldContactId, &contactChangeListener);
     deleteTestContact(newContactId, &contactChangeListener);

--- a/tests/ut_recipienteventmodel/recipienteventmodeltest.cpp
+++ b/tests/ut_recipienteventmodel/recipienteventmodeltest.cpp
@@ -92,7 +92,7 @@ void RecipientEventModelTest::testGetRecipientEvents()
     QCOMPARE(event.recipients().first(), testRecipient);
 
     // Reset to an unused recipient
-    model.setRecipients(Recipient(RING_ACCOUNT, "not-a-real-number"));
+    model.setRecipients(Recipient::fromPhoneNumber("not-a-real-number"));
     QVERIFY(model.getEvents());
     QTRY_VERIFY(model.isReady());
     QCOMPARE(model.rowCount(), 0);
@@ -178,7 +178,7 @@ void RecipientEventModelTest::testGetContactEvents()
     QCOMPARE(event.contactName(), QString("Correspondent"));
 
     // Reset to an unused recipient
-    model.setRecipients(Recipient(RING_ACCOUNT, "not-a-real-number"));
+    model.setRecipients(Recipient::fromPhoneNumber("not-a-real-number"));
     QVERIFY(model.getEvents());
     QTRY_VERIFY(model.isReady());
     QCOMPARE(model.rowCount(), 0);


### PR DESCRIPTION
Allow to create recipients from phone numbers, the ring account is then assumed.