### PR TITLE
[libcommhistory] Add missing lcCommHistory category in declarative.

### DIFF
--- a/declarative/declarative.pro
+++ b/declarative/declarative.pro
@@ -13,6 +13,7 @@ SOURCES += src/plugin.cpp \
     src/conversationproxymodel.cpp \
     src/declarativegroupmanager.cpp \
     src/sharedbackgroundthread.cpp \
+    src/debug.cpp \
     src/mmshelper.cpp \
     src/draftevent.cpp
 

--- a/declarative/src/callproxymodel.cpp
+++ b/declarative/src/callproxymodel.cpp
@@ -1,6 +1,7 @@
 #include "callproxymodel.h"
 #include "event.h"
 #include "eventmodel.h"
+#include "debug.h"
 
 using namespace CommHistory;
 
@@ -33,7 +34,7 @@ void CallProxyModel::componentComplete()
     connect(this, SIGNAL(modelReady(bool)), this, SLOT(onReadyChanged(bool)));
 
     if (!getEvents()) {
-        qWarning() << "getEvents() failed on CommHistory::CallModel";
+        qCWarning(lcCommHistory) << "getEvents() failed on CommHistory::CallModel";
     }
 }
 

--- a/declarative/src/debug.cpp
+++ b/declarative/src/debug.cpp
@@ -1,0 +1,3 @@
+#include "debug.h"
+
+Q_LOGGING_CATEGORY(lcCommHistory, "com.nokia.commhistory", QtWarningMsg)

--- a/declarative/src/debug.h
+++ b/declarative/src/debug.h
@@ -23,14 +23,8 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#include <QDebug>
+#include <QtCore/QLoggingCategory>
 
-// Define this if you'd like to see debug messages from declarative commhistory module
-// #define DEBUG_COMMHISTORY
-#ifdef DEBUG_COMMHISTORY
-# define DEBUG qDebug
-#else
-# define DEBUG if (0) qDebug
-#endif
+Q_DECLARE_LOGGING_CATEGORY(lcCommHistory)
 
 #endif // DEBUG_H

--- a/declarative/src/declarativegroupmanager.cpp
+++ b/declarative/src/declarativegroupmanager.cpp
@@ -33,7 +33,7 @@
 #include "sharedbackgroundthread.h"
 #include "singleeventmodel.h"
 #include <QTimer>
-#include "debug_p.h"
+#include "debug.h"
 
 using namespace CommHistory;
 

--- a/declarative/src/declarativegroupmanager.cpp
+++ b/declarative/src/declarativegroupmanager.cpp
@@ -143,7 +143,7 @@ int DeclarativeGroupManager::createOutgoingMessageEvent(int groupId, const QStri
         groupId = ensureGroupExists(localUid, remoteUids);
     }
     if (groupId < 0) {
-        qWarning() << Q_FUNC_INFO << "Failed finding group for UIDs:" << localUid << remoteUids;
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Failed finding group for UIDs:" << localUid << remoteUids;
         return -1;
     }
 
@@ -153,7 +153,7 @@ int DeclarativeGroupManager::createOutgoingMessageEvent(int groupId, const QStri
     if (model.addEvent(event))
         return event.id();
 
-    qWarning() << Q_FUNC_INFO << "Failed creating event";
+    qCWarning(lcCommHistory) << Q_FUNC_INFO << "Failed creating event";
     return -1;
 }
 
@@ -167,11 +167,11 @@ void DeclarativeGroupManager::createOutgoingMessageEvent(int groupId, const QStr
                                                         const QStringList &remoteUids, const QString &text, QJSValue callback)
 {
     if (!callback.isCallable()) {
-        qWarning() << Q_FUNC_INFO << "Invalid callback argument:" << callback.toString();
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Invalid callback argument:" << callback.toString();
         return;
     }
     if (!useBackgroundThread()) {
-        qWarning() << Q_FUNC_INFO << "useBackgroundThread must be true to use asynchronous message event creation";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "useBackgroundThread must be true to use asynchronous message event creation";
         return;
     }
 
@@ -179,7 +179,7 @@ void DeclarativeGroupManager::createOutgoingMessageEvent(int groupId, const QStr
         groupId = ensureGroupExists(localUid, remoteUids);
     }
     if (groupId < 0) {
-        qWarning() << Q_FUNC_INFO << "Failed finding group for UIDs:" << localUid << remoteUids;
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Failed finding group for UIDs:" << localUid << remoteUids;
         callback.call(QJSValueList() << QJSValue(-1));
         return;
     }
@@ -196,7 +196,7 @@ void DeclarativeGroupManager::createOutgoingMessageEvent(int groupId, const QStr
 
         QMetaObject::invokeMethod(writer, "writeEvent", Qt::QueuedConnection);
     } else {
-        qWarning() << Q_FUNC_INFO << "Could not dispatch event write to background thread";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Could not dispatch event write to background thread";
     }
 }
 
@@ -210,7 +210,7 @@ bool DeclarativeGroupManager::setEventStatus(int eventId, int status)
 {
     SingleEventModel model;
     if (!model.getEventById(eventId)) {
-        qWarning() << Q_FUNC_INFO << "No event with id" << eventId;
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "No event with id" << eventId;
         return false;
     }
 
@@ -235,7 +235,7 @@ int DeclarativeGroupManager::ensureGroupExists(const QString &localUid, const QS
         g.setChatType(Group::ChatTypeP2P);
         qCDebug(lcCommHistory) << Q_FUNC_INFO << "Creating group for" << localUid << remoteUids;
         if (!addGroup(g)) {
-            qWarning() << Q_FUNC_INFO << "Failed creating group";
+            qCWarning(lcCommHistory) << Q_FUNC_INFO << "Failed creating group";
             return -1;
         }
         return g.id();

--- a/declarative/src/draftevent.cpp
+++ b/declarative/src/draftevent.cpp
@@ -32,7 +32,6 @@
 #include "draftevent.h"
 #include "singleeventmodel.h"
 #include "commonutils.h"
-#include <QDebug>
 
 using namespace CommHistory;
 

--- a/declarative/src/draftevent.cpp
+++ b/declarative/src/draftevent.cpp
@@ -32,6 +32,7 @@
 #include "draftevent.h"
 #include "singleeventmodel.h"
 #include "commonutils.h"
+#include "debug.h"
 
 using namespace CommHistory;
 
@@ -60,7 +61,7 @@ void DraftEvent::reset()
 void DraftEvent::save()
 {
     if (!isValid()) {
-        qWarning() << "DraftEvent cannot save invalid event:" << m_event.toString();
+        qCWarning(lcCommHistory) << "DraftEvent cannot save invalid event:" << m_event.toString();
         return;
     }
 
@@ -77,10 +78,10 @@ void DraftEvent::save()
 
     if (m_event.id() < 0) {
         if (!model.addEvent(m_event))
-            qWarning() << "DraftEvent add failed:" << m_event.toString();
+            qCWarning(lcCommHistory) << "DraftEvent add failed:" << m_event.toString();
     } else {
         if (!model.modifyEvent(m_event))
-            qWarning() << "DraftEvent modify failed:" << m_event.toString();
+            qCWarning(lcCommHistory) << "DraftEvent modify failed:" << m_event.toString();
     }
 }
 
@@ -88,7 +89,7 @@ void DraftEvent::deleteEvent()
 {
     SingleEventModel model;
     if (m_event.id() >= 0 && !model.deleteEvent(m_event))
-        qWarning() << "DraftEvent delete failed:" << m_event.toString();
+        qCWarning(lcCommHistory) << "DraftEvent delete failed:" << m_event.toString();
 }
 
 Event DraftEvent::event() const
@@ -158,7 +159,7 @@ void DraftEvent::setRemoteUids(const QStringList &remoteUids)
         return;
 
     if (m_event.localUid().isEmpty()) {
-        qWarning() << "DraftEvent cannot set remote UIDs without a local UID";
+        qCWarning(lcCommHistory) << "DraftEvent cannot set remote UIDs without a local UID";
         return;
     }
 

--- a/declarative/src/mmshelper.cpp
+++ b/declarative/src/mmshelper.cpp
@@ -36,7 +36,6 @@
 #include <QTextCodec>
 #include <QTemporaryDir>
 #include <QMimeDatabase>
-#include <QDebug>
 
 #include <unistd.h>
 

--- a/declarative/src/sharedbackgroundthread.cpp
+++ b/declarative/src/sharedbackgroundthread.cpp
@@ -30,7 +30,7 @@
  */
 
 #include "sharedbackgroundthread.h"
-#include "debug_p.h"
+#include "debug.h"
 
 static void stopAndDeleteThread(QThread *thread)
 {

--- a/src/callhistory.cpp
+++ b/src/callhistory.cpp
@@ -22,8 +22,8 @@
 #include "callhistory_p.h"
 #include "databaseio_p.h"
 #include "event.h"
+#include "debug_p.h"
 
-#include <QtDebug>
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QSqlDatabase>
@@ -149,8 +149,8 @@ bool CallHistory::reload()
     d->results.clear();
 
     if (d->startTime.isValid() && d->endTime.isValid() && d->endTime <= d->startTime) {
-        qWarning() << "Error: end time" << d->endTime.toString()
-                   << "is not after start time" << d->startTime.toString();
+        qCWarning(lcCommHistory) << "Error: end time" << d->endTime.toString()
+                                 << "is not after start time" << d->startTime.toString();
         return false;
     }
 
@@ -158,8 +158,8 @@ bool CallHistory::reload()
 
     QSqlQuery query = DatabaseIOPrivate::prepareQuery(queryString);
     if (!query.exec()) {
-        qWarning() << "Failed to execute query:" << query.lastQuery();
-        qWarning() << "Error was:" << query.lastError();
+        qCWarning(lcCommHistory) << "Failed to execute query:" << query.lastQuery();
+        qCWarning(lcCommHistory) << "Error was:" << query.lastError();
         return false;
     }
 

--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -590,7 +590,7 @@ void CallModelPrivate::insertEvent(Event event)
         }
         default:
         {
-            qWarning() << Q_FUNC_INFO << "Adding call events to model sorted by type or by service has not been implemented yet.";
+            qCWarning(lcCommHistory) << Q_FUNC_INFO << "Adding call events to model sorted by type or by service has not been implemented yet.";
             return;
         }
     }
@@ -796,7 +796,7 @@ void CallModelPrivate::slotAllCallsDeleted(int unused)
     Q_UNUSED(unused);
     Q_Q(CallModel);
 
-    qWarning() << Q_FUNC_INFO << "clearing model";
+    qCDebug(lcCommHistory) << Q_FUNC_INFO << "clearing model";
 
     q->beginResetModel();
     clearEvents();
@@ -1062,7 +1062,7 @@ bool CallModel::deleteAll()
     bool deleted;
     deleted = d->database()->deleteAllEvents(Event::CallEvent);
     if (!deleted) {
-        qWarning() << Q_FUNC_INFO << "Failed to delete events";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Failed to delete events";
         return false;
     }
 
@@ -1078,7 +1078,7 @@ bool CallModel::markAllRead()
     bool marked;
     marked = d->database()->markAsReadAll(Event::CallEvent);
     if (!marked) {
-        qWarning() << Q_FUNC_INFO << "Failed to mark events as read";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Failed to mark events as read";
         return false;
     }
 
@@ -1100,7 +1100,7 @@ bool CallModel::modifyEvent(Event &event)
     }
 
     if (event.id() == -1) {
-        qWarning() << Q_FUNC_INFO << "Event id not set";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Event id not set";
         return false;
     }
 
@@ -1179,7 +1179,7 @@ bool CallModel::deleteEvent(int id)
         }
         default:
         {
-            qWarning() << Q_FUNC_INFO << "Deleting of call events from model sorted by type or by service has not been implemented yet.";
+            qCWarning(lcCommHistory) << Q_FUNC_INFO << "Deleting of call events from model sorted by type or by service has not been implemented yet.";
             return false;
         }
     }

--- a/src/callstatistics.cpp
+++ b/src/callstatistics.cpp
@@ -1,6 +1,7 @@
 #include "callstatistics_p.h"
 #include "databaseio_p.h"
 #include "event.h"
+#include "debug_p.h"
 
 #include <QtDebug>
 #include <QSqlQuery>
@@ -259,8 +260,8 @@ bool CallStatistics::reload()
     d->results.clear();
 
     if (d->startTime.isValid() && d->endTime.isValid() && d->endTime <= d->startTime) {
-        qWarning() << "Error: end time" << d->endTime.toString()
-                   << "is not after start time" << d->startTime.toString();
+        qCWarning(lcCommHistory) << "Error: end time" << d->endTime.toString()
+                                 << "is not after start time" << d->startTime.toString();
         return false;
     }
 
@@ -268,8 +269,8 @@ bool CallStatistics::reload()
 
     QSqlQuery query = DatabaseIOPrivate::prepareQuery(queryString);
     if (!query.exec()) {
-        qWarning() << "Failed to execute query:" << query.lastQuery();
-        qWarning() << "Error was:" << query.lastError();
+        qCWarning(lcCommHistory) << "Failed to execute query:" << query.lastQuery();
+        qCWarning(lcCommHistory) << "Error was:" << query.lastError();
         return false;
     }
 

--- a/src/commhistorydatabase.cpp
+++ b/src/commhistorydatabase.cpp
@@ -22,11 +22,11 @@
 
 #include "commhistorydatabase.h"
 #include "commhistorydatabasepath.h"
+#include "debug_p.h"
 #include <QDir>
 #include <QFile>
 #include <QSqlError>
 #include <QSqlQuery>
-#include <QDebug>
 #include <QStandardPaths>
 #include <QCoreApplication>
 
@@ -216,9 +216,9 @@ static bool execute(QSqlDatabase &database, const QString &statement)
 {
     QSqlQuery query(database);
     if (!query.exec(statement)) {
-        qWarning() << "Query failed";
-        qWarning() << query.lastError();
-        qWarning() << statement;
+        qCWarning(lcCommHistory) << "Query failed";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << statement;
         return false;
     } else {
         return true;
@@ -235,9 +235,9 @@ static bool prepareDatabase(QSqlDatabase &database)
         QSqlQuery query(database);
 
         if (!query.exec(QLatin1String(db_schema[i]))) {
-            qWarning() << "Table creation failed";
-            qWarning() << query.lastError();
-            qWarning() << db_schema[i];
+            qCWarning(lcCommHistory) << "Table creation failed";
+            qCWarning(lcCommHistory) << query.lastError();
+            qCWarning(lcCommHistory) << db_schema[i];
             error = true;
             break;
         }
@@ -256,7 +256,7 @@ static bool upgradeDatabase(QSqlDatabase &database)
     QSqlQuery query(database);
     query.prepare("PRAGMA user_version");
     if (!query.exec() || !query.next()) {
-        qWarning() << "User version query failed:" << query.lastError();
+        qCWarning(lcCommHistory) << "User version query failed:" << query.lastError();
         return false;
     }
 
@@ -264,7 +264,7 @@ static bool upgradeDatabase(QSqlDatabase &database)
     query.finish();
 
     while (user_version < db_upgrade_count) {
-        qWarning() << "Upgrading commhistory database from schema version" << user_version;
+        qCWarning(lcCommHistory) << "Upgrading commhistory database from schema version" << user_version;
 
         for (unsigned i = 0; db_upgrade[user_version][i]; i++) {
             if (!execute(database, QLatin1String(db_upgrade[user_version][i])))
@@ -272,7 +272,7 @@ static bool upgradeDatabase(QSqlDatabase &database)
         }
 
         if (!query.exec() || !query.next()) {
-            qWarning() << "User version query failed:" << query.lastError();
+            qCWarning(lcCommHistory) << "User version query failed:" << query.lastError();
             return false;
         }
 
@@ -281,7 +281,7 @@ static bool upgradeDatabase(QSqlDatabase &database)
     }
 
     if (user_version > db_upgrade_count)
-        qWarning() << "Commhistory database schema is newer than expected - this may result in failures or corruption";
+        qCWarning(lcCommHistory) << "Commhistory database schema is newer than expected - this may result in failures or corruption";
 
     return true;
 }
@@ -299,11 +299,11 @@ QSqlDatabase CommHistoryDatabase::open(const QString &databaseName)
     database.setDatabaseName(databaseFile);
 
     if (!database.open()) {
-        qWarning() << "Failed to open commhistory database";
-        qWarning() << database.lastError();
+        qCWarning(lcCommHistory) << "Failed to open commhistory database";
+        qCWarning(lcCommHistory) << database.lastError();
         return database;
     } else {
-        qWarning() << "Opened commhistory database:" << databaseFile;
+        qCWarning(lcCommHistory) << "Opened commhistory database:" << databaseFile;
     }
 
     for (int i = 0; i < db_setup_count; i++) {
@@ -340,9 +340,9 @@ QSqlQuery CommHistoryDatabase::prepare(const char *statement, const QSqlDatabase
     QSqlQuery query(database);
     query.setForwardOnly(true);
     if (!query.prepare(statement)) {
-        qWarning() << "Failed to prepare query";
-        qWarning() << query.lastError();
-        qWarning() << statement;
+        qCWarning(lcCommHistory) << "Failed to prepare query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << statement;
         return QSqlQuery();
     }
     return query;

--- a/src/contactresolver.cpp
+++ b/src/contactresolver.cpp
@@ -25,6 +25,7 @@
 #include <QElapsedTimer>
 
 #include "recipient_p.h"
+#include "debug_p.h"
 
 #include <seasidecache.h>
 
@@ -172,7 +173,7 @@ bool ContactResolverPrivate::checkIfFinished()
 void ContactResolverPrivate::addressResolved(const QString &first, const QString &second, SeasideCache::CacheItem *item)
 {
     if (second.isEmpty()) {
-        qWarning() << "Got addressResolved with empty UIDs" << first << second << item;
+        qCWarning(lcCommHistory) << "Got addressResolved with empty UIDs" << first << second << item;
         return;
     } else if (first.isEmpty()) {
         // This resolution is for a phone number - we need to call back to libcontacts

--- a/src/databaseio.cpp
+++ b/src/databaseio.cpp
@@ -189,7 +189,7 @@ public:
                 case Event::EventCount:
                     break;
                 default:
-                    qWarning() << Q_FUNC_INFO << "Event field ignored:" << property;
+                    qCWarning(lcCommHistory) << Q_FUNC_INFO << "Event field ignored:" << property;
                     break;
             }
         }
@@ -236,7 +236,7 @@ public:
                 case Group::SubscriberIdentity:
                     break;
                 default:
-                    qWarning() << Q_FUNC_INFO << "Group field ignored:" << property;
+                    qCWarning(lcCommHistory) << Q_FUNC_INFO << "Group field ignored:" << property;
                     break;
             }
         }
@@ -272,7 +272,7 @@ public:
         QSqlQuery query(db);
         bool re = query.exec("SAVEPOINT " + name);
         if (!re)
-            qWarning() << "Database savepoint failed:" << query.lastError();
+            qCWarning(lcCommHistory) << "Database savepoint failed:" << query.lastError();
         else
             active = true;
         return re;
@@ -285,7 +285,7 @@ public:
         QSqlQuery query(db);
         bool re = query.exec("RELEASE " + name);
         if (!re)
-            qWarning() << "Database savepoint release failed:" << query.lastError();
+            qCWarning(lcCommHistory) << "Database savepoint release failed:" << query.lastError();
         else
             active = false;
         return re;
@@ -298,7 +298,7 @@ public:
         QSqlQuery query(db);
         bool re = query.exec("ROLLBACK TO " + name);
         if (!re)
-            qWarning() << "Database savepoint rollback failed:" << query.lastError();
+            qCWarning(lcCommHistory) << "Database savepoint rollback failed:" << query.lastError();
         else
             active = false;
         return re;
@@ -365,22 +365,22 @@ QSqlQuery DatabaseIOPrivate::createQuery()
 bool DatabaseIO::addEvent(Event &event)
 {
     if (event.type() == Event::UnknownType) {
-        qWarning() << Q_FUNC_INFO << "Event type not set";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Event type not set";
         return false;
     }
 
     if (event.direction() == Event::UnknownDirection) {
-        qWarning() << Q_FUNC_INFO << "Event direction not set";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Event direction not set";
         return false;
     }
 
     if (event.groupId() == -1 && event.type() != Event::CallEvent) {
-        qWarning() << Q_FUNC_INFO << "Group id not set";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Group id not set";
         return false;
     }
 
     if (event.id() != -1)
-        qWarning() << Q_FUNC_INFO << "Adding event with an ID set. ID will be ignored.";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Adding event with an ID set. ID will be ignored.";
 
     AutoSavepoint savepoint(d->connection());
     if (!savepoint.begin())
@@ -390,9 +390,9 @@ bool DatabaseIO::addEvent(Event &event)
     QSqlQuery query = QueryHelper::insertQuery("INSERT INTO Events (:fields) VALUES (:values)", fields);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -420,9 +420,9 @@ bool DatabaseIOPrivate::insertEventProperties(int eventId, const QVariantMap &pr
         query.bindValue(":key", it.key());
         query.bindValue(":value", it.value().toString());
         if (!query.exec()) {
-            qWarning() << "Failed to execute query";
-            qWarning() << query.lastError();
-            qWarning() << query.lastQuery();
+            qCWarning(lcCommHistory) << "Failed to execute query";
+            qCWarning(lcCommHistory) << query.lastError();
+            qCWarning(lcCommHistory) << query.lastQuery();
             return false;
         }
     }
@@ -452,9 +452,9 @@ bool DatabaseIOPrivate::insertMessageParts(Event &event)
         query.bindValue(":contentType", part.contentType());
         query.bindValue(":path", part.path());
         if (!query.exec()) {
-            qWarning() << "Failed to execute query";
-            qWarning() << query.lastError();
-            qWarning() << query.lastQuery();
+            qCWarning(lcCommHistory) << "Failed to execute query";
+            qCWarning(lcCommHistory) << query.lastError();
+            qCWarning(lcCommHistory) << query.lastQuery();
             return false;
         }
         if (part.id() < 0)
@@ -481,9 +481,9 @@ bool DatabaseIO::reserveEventIds(int count, int *firstReservedId)
             DatabaseIOPrivate::instance()->connection());
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         rollback();
         return false;
     }
@@ -501,9 +501,9 @@ bool DatabaseIO::reserveEventIds(int count, int *firstReservedId)
     update.bindValue(":seq", lastReservedId);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         rollback();
         return false;
     }
@@ -664,9 +664,9 @@ bool DatabaseIO::getEvent(int id, Event &event)
     query.bindValue(":eventId", id);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -695,9 +695,9 @@ bool DatabaseIO::getEventExtraProperties(Event &event)
     query.bindValue(":eventId", event.id());
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -716,9 +716,9 @@ bool DatabaseIO::getMessageParts(Event &event)
     query.bindValue(":eventId", event.id());
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -744,9 +744,9 @@ bool DatabaseIO::getEventByMessageToken(const QString &token, Event &event)
     query.bindValue(":messageToken", token);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -796,9 +796,9 @@ bool DatabaseIO::getEventByMmsId(const QString &mmsId, Event &event)
                 }
             }
         } else {
-            qWarning() << "Failed to execute query";
-            qWarning() << query.lastError();
-            qWarning() << query.lastQuery();
+            qCWarning(lcCommHistory) << "Failed to execute query";
+            qCWarning(lcCommHistory) << query.lastError();
+            qCWarning(lcCommHistory) << query.lastQuery();
         }
     }
 
@@ -815,9 +815,9 @@ bool DatabaseIO::eventExists(int id)
     if (query.exec()) {
         return query.next();
     } else {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 }
@@ -833,9 +833,9 @@ bool DatabaseIO::modifyEvent(Event &event)
     query.bindValue(":eventId", event.id());
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
     query.finish();
@@ -845,9 +845,9 @@ bool DatabaseIO::modifyEvent(Event &event)
         query = CommHistoryDatabase::prepare(q, d->connection());
         query.bindValue(":eventId", event.id());
         if (!query.exec()) {
-            qWarning() << "Failed to execute query";
-            qWarning() << query.lastError();
-            qWarning() << query.lastQuery();
+            qCWarning(lcCommHistory) << "Failed to execute query";
+            qCWarning(lcCommHistory) << query.lastError();
+            qCWarning(lcCommHistory) << query.lastQuery();
             return false;
         }
         query.finish();
@@ -873,9 +873,9 @@ bool DatabaseIO::modifyEvent(Event &event)
         query = CommHistoryDatabase::prepare(q, d->connection());
         query.bindValue(":eventId", event.id());
         if (!query.exec()) {
-            qWarning() << "Failed to execute query";
-            qWarning() << query.lastError();
-            qWarning() << query.lastQuery();
+            qCWarning(lcCommHistory) << "Failed to execute query";
+            qCWarning(lcCommHistory) << query.lastError();
+            qCWarning(lcCommHistory) << query.lastQuery();
             return false;
         }
         query.finish();
@@ -895,9 +895,9 @@ bool DatabaseIO::moveEvent(Event &event, int groupId)
     query.bindValue(":id", event.id());
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -912,9 +912,9 @@ bool DatabaseIO::deleteEvent(Event &event, QThread *)
     query.bindValue(":id", event.id());
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -924,7 +924,7 @@ bool DatabaseIO::deleteEvent(Event &event, QThread *)
 bool DatabaseIO::addGroup(Group &group)
 {
     if (group.localUid().isEmpty() || group.recipients().isEmpty()) {
-        qWarning() << Q_FUNC_INFO << "No local/remote UIDs for new group";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "No local/remote UIDs for new group";
         return false;
     }
 
@@ -932,9 +932,9 @@ bool DatabaseIO::addGroup(Group &group)
     QSqlQuery query = QueryHelper::insertQuery("INSERT INTO Groups (:fields) VALUES (:values)", fields);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1028,9 +1028,9 @@ bool DatabaseIO::getGroup(int id, Group &group)
     query.bindValue(":groupId", id);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1068,9 +1068,9 @@ bool DatabaseIO::getGroups(const QString &localUid, const QString &remoteUid, QL
         query.bindValue(":remoteUid", remoteUid);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1091,9 +1091,9 @@ bool DatabaseIO::modifyGroup(Group &group)
     query.bindValue(":groupId", group.id());
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1125,9 +1125,9 @@ bool DatabaseIO::deleteGroups(QList<int> groupIds, QThread *backgroundThread)
     QSqlQuery query = CommHistoryDatabase::prepare(q, d->connection());
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1141,9 +1141,9 @@ bool DatabaseIO::totalEventsInGroup(int groupId, int &totalEvents)
     query.bindValue(":groupId", groupId);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1162,9 +1162,9 @@ bool DatabaseIO::markAsReadGroup(int groupId)
     query.bindValue(":groupId", groupId);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1178,9 +1178,9 @@ bool DatabaseIO::markAsRead(const QList<int> &eventIds)
 
     QSqlQuery query = CommHistoryDatabase::prepare(q, d->connection());
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1194,9 +1194,9 @@ bool DatabaseIO::markAsReadAll(Event::EventType eventType)
     query.bindValue(":eventType", eventType);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1214,9 +1214,9 @@ bool DatabaseIO::deleteAllEvents(Event::EventType eventType)
         query.bindValue(":eventType", eventType);
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1228,9 +1228,9 @@ bool DatabaseIOPrivate::deleteEmptyGroups()
     static const char *q = "DELETE FROM Groups WHERE (SELECT COUNT(id) FROM Events WHERE groupId=Groups.id) = 0";
     QSqlQuery query = CommHistoryDatabase::prepare(q, connection());
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 
@@ -1244,8 +1244,8 @@ bool DatabaseIO::transaction()
 {
     bool re = d->connection().transaction();
     if (!re) {
-        qWarning() << "Failed to start transaction";
-        qWarning() << d->connection().lastError();
+        qCWarning(lcCommHistory) << "Failed to start transaction";
+        qCWarning(lcCommHistory) << d->connection().lastError();
     }
     return re;
 }
@@ -1254,8 +1254,8 @@ bool DatabaseIO::commit()
 {
     bool re = d->connection().commit();
     if (!re) {
-        qWarning() << "Failed to commit transaction";
-        qWarning() << d->connection().lastError();
+        qCWarning(lcCommHistory) << "Failed to commit transaction";
+        qCWarning(lcCommHistory) << d->connection().lastError();
         rollback();
     }
     return re;
@@ -1265,8 +1265,8 @@ bool DatabaseIO::rollback()
 {
     bool re = d->connection().rollback();
     if (!re) {
-        qWarning() << "Failed to rollback transaction";
-        qWarning() << d->connection().lastError();
+        qCWarning(lcCommHistory) << "Failed to rollback transaction";
+        qCWarning(lcCommHistory) << d->connection().lastError();
     }
     return re;
 }

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -28,6 +28,7 @@
 #include "event.h"
 #include "messagepart.h"
 #include "dbus_p.h"
+#include "debug_p.h"
 
 #include <QStringBuilder>
 
@@ -1041,7 +1042,7 @@ void Event::setExtraProperty(const QString &key, const QVariant &value)
     }
 
     if (!value.canConvert<QString>())
-        qWarning() << "Event extra property" << key << "type cannot be converted to string:" << value;
+        qCWarning(lcCommHistory) << "Event extra property" << key << "type cannot be converted to string:" << value;
 
     d->extraProperties.insert(key, value);
     d->propertyChanged(Event::ExtraProperties);

--- a/src/eventmodel.cpp
+++ b/src/eventmodel.cpp
@@ -386,7 +386,7 @@ void EventModel::setQueryMode(QueryMode mode)
 
     d->queryMode = mode;
     if (d->queryMode == SyncQuery && d->resolveContacts == ResolveImmediately)
-        qWarning() << "EventMode does not support immediate contact resolution for synchronous models. Contacts will not be resolved.";
+        qCWarning(lcCommHistory) << "EventMode does not support immediate contact resolution for synchronous models. Contacts will not be resolved.";
 }
 
 void EventModel::setChunkSize(uint size)
@@ -447,7 +447,7 @@ void EventModel::setResolveContacts(ContactResolveType resolveType)
         return;
 
     if (d->queryMode == SyncQuery && resolveType == ResolveImmediately)
-        qWarning() << "EventMode does not support immediate contact resolution for synchronous models. Contacts will not be resolved.";
+        qCWarning(lcCommHistory) << "EventMode does not support immediate contact resolution for synchronous models. Contacts will not be resolved.";
 
     d->setResolveContacts(resolveType);
 }
@@ -525,7 +525,7 @@ bool EventModel::modifyEvents(QList<Event> &events)
     for (QList<Event>::Iterator it = events.begin(); it != events.end(); it++) {
         Event &event = *it;
         if (event.id() == -1) {
-            qWarning() << Q_FUNC_INFO << "Event id not set";
+            qCWarning(lcCommHistory) << Q_FUNC_INFO << "Event id not set";
             d->database()->rollback();
             return false;
         }
@@ -578,7 +578,7 @@ bool EventModel::deleteEvent(Event &event)
     qCDebug(lcCommHistory) << Q_FUNC_INFO << ":" << event.id();
 
     if (!event.isValid()) {
-        qWarning() << Q_FUNC_INFO << "Invalid event";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Invalid event";
         return false;
     }
 
@@ -631,7 +631,7 @@ bool EventModel::moveEvent(Event &event, int groupId)
     qCDebug(lcCommHistory) << Q_FUNC_INFO << ":" << event.id();
 
     if (!event.isValid()) {
-        qWarning() << Q_FUNC_INFO << "Invalid event";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Invalid event";
         return false;
     }
 
@@ -661,7 +661,7 @@ bool EventModel::moveEvent(Event &event, int groupId)
         if (total == 0) {
             qCDebug(lcCommHistory) << Q_FUNC_INFO << ": deleting empty group";
             if (!d->database()->deleteGroup(oldGroupId)) {
-                qWarning() << Q_FUNC_INFO << "error deleting empty group" ;
+                qCWarning(lcCommHistory) << Q_FUNC_INFO << "error deleting empty group" ;
                 d->database()->rollback();
                 return false;
             } else {
@@ -699,7 +699,7 @@ bool EventModel::modifyEventsInGroup(QList<Event> &events, Group group)
     for (QList<Event>::Iterator it = events.begin(); it != events.end(); it++) {
         Event &event = *it;
         if (event.id() == -1) {
-            qWarning() << Q_FUNC_INFO << "Event id not set";
+            qCWarning(lcCommHistory) << Q_FUNC_INFO << "Event id not set";
             d->database()->rollback();
             return false;
         }

--- a/src/eventmodel_p.cpp
+++ b/src/eventmodel_p.cpp
@@ -159,9 +159,9 @@ bool EventModelPrivate::executeQuery(QSqlQuery &query)
     isReady = false;
 
     if (!query.exec()) {
-        qWarning() << "Failed to execute query";
-        qWarning() << query.lastError();
-        qWarning() << query.lastQuery();
+        qCWarning(lcCommHistory) << "Failed to execute query";
+        qCWarning(lcCommHistory) << query.lastError();
+        qCWarning(lcCommHistory) << query.lastQuery();
         return false;
     }
 

--- a/src/groupmanager.cpp
+++ b/src/groupmanager.cpp
@@ -519,7 +519,7 @@ bool GroupManager::modifyGroup(Group &group)
     qCDebug(lcCommHistory) << Q_FUNC_INFO << group.id();
 
     if (group.id() == -1) {
-        qWarning() << Q_FUNC_INFO << "Group id not set";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << "Group id not set";
         return false;
     }
 

--- a/src/messagepart.cpp
+++ b/src/messagepart.cpp
@@ -21,7 +21,6 @@
 **
 ******************************************************************************/
 
-#include <QDebug>
 #include <QSharedDataPointer>
 #include <QDBusArgument>
 #include <QStringBuilder>
@@ -30,6 +29,7 @@
 #include <QTextCodec>
 #include <QDataStream>
 #include "messagepart.h"
+#include "debug_p.h"
 
 namespace CommHistory {
 
@@ -182,7 +182,7 @@ QString MessagePart::plainTextContent() const
 
     QFile file(d->path);
     if (!file.open(QIODevice::ReadOnly)) {
-        qWarning() << "Message part" << id() << "at" << path() << "can't be read";
+        qCWarning(lcCommHistory) << "Message part" << id() << "at" << path() << "can't be read";
         return QString();
     }
 
@@ -196,7 +196,7 @@ QString MessagePart::plainTextContent() const
 
         codec = QTextCodec::codecForName(charset.toLatin1());
         if (!codec)
-            qWarning() << "Missing text codec for" << charset << "when parsing content of type" << d->contentType;
+            qCWarning(lcCommHistory) << "Missing text codec for" << charset << "when parsing content of type" << d->contentType;
     }
 
     if (codec)

--- a/src/smshistory.cpp
+++ b/src/smshistory.cpp
@@ -22,6 +22,7 @@
 #include "smshistory_p.h"
 #include "databaseio_p.h"
 #include "event.h"
+#include "debug_p.h"
 
 #include <QtDebug>
 #include <QSqlQuery>
@@ -119,8 +120,8 @@ bool SMSHistory::reload()
     d->results.clear();
 
     if (d->startTime.isValid() && d->endTime.isValid() && d->endTime <= d->startTime) {
-        qWarning() << "Error: end time" << d->endTime.toString()
-                   << "is not after start time" << d->startTime.toString();
+        qCWarning(lcCommHistory) << "Error: end time" << d->endTime.toString()
+                                 << "is not after start time" << d->startTime.toString();
         return false;
     }
 
@@ -128,8 +129,8 @@ bool SMSHistory::reload()
 
     QSqlQuery query = DatabaseIOPrivate::prepareQuery(queryString);
     if (!query.exec()) {
-        qWarning() << "Failed to execute query:" << query.lastQuery();
-        qWarning() << "Error was:" << query.lastError();
+        qCWarning(lcCommHistory) << "Failed to execute query:" << query.lastQuery();
+        qCWarning(lcCommHistory) << "Error was:" << query.lastError();
         return false;
     }
 

--- a/src/updatesemitter.cpp
+++ b/src/updatesemitter.cpp
@@ -26,6 +26,7 @@
 
 #include "updatesemitter.h"
 #include "dbus_p.h"
+#include "debug_p.h"
 
 namespace CommHistory {
 
@@ -36,7 +37,7 @@ UpdatesEmitter::UpdatesEmitter()
     new Adaptor(this);
     if (!QDBusConnection::sessionBus().registerObject(COMM_HISTORY_OBJECT_PATH,
                                                       this)) {
-        qWarning() << Q_FUNC_INFO << ": error registering object";
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << ": error registering object";
     }
 }
 


### PR DESCRIPTION
It should fix the issue I created in the declarative part, replacing the old QDEBUG() call without providing an implementation for the lcCommHistory symbol.