### PR TITLE
[libcommhistory] Give a service name to the object on D-Bus.

### DIFF
--- a/src/dbus_p.h
+++ b/src/dbus_p.h
@@ -29,6 +29,7 @@
 #include "messagepart.h"
 #include "group.h"
 
+#define COMM_HISTORY_SERVICE_NAME_PREFIX QLatin1String("com.nokia.commhistory")
 #define COMM_HISTORY_INTERFACE     QLatin1String("com.nokia.commhistory")
 #define COMM_HISTORY_OBJECT_PATH   QLatin1String("/CommHistoryModel")
 

--- a/src/updatesemitter.cpp
+++ b/src/updatesemitter.cpp
@@ -21,6 +21,7 @@
 ******************************************************************************/
 
 #include <QtDBus/QtDBus>
+#include <QCoreApplication>
 
 #include "adaptor.h"
 
@@ -31,6 +32,7 @@
 namespace CommHistory {
 
 QWeakPointer<UpdatesEmitter> UpdatesEmitter::m_Instance;
+QString m_serviceName;
 
 UpdatesEmitter::UpdatesEmitter()
 {
@@ -39,11 +41,19 @@ UpdatesEmitter::UpdatesEmitter()
                                                       this)) {
         qCWarning(lcCommHistory) << Q_FUNC_INFO << ": error registering object";
     }
+    m_serviceName
+        = QString::fromLatin1("%1.p%2").arg(COMM_HISTORY_SERVICE_NAME_PREFIX,
+                                            QCoreApplication::applicationPid());
+    if (!QDBusConnection::sessionBus().registerService(m_serviceName)) {
+        qCWarning(lcCommHistory) << Q_FUNC_INFO << ": error registering service"
+                                 << QDBusConnection::sessionBus().lastError();
+    }
 }
 
 UpdatesEmitter::~UpdatesEmitter()
 {
     QDBusConnection::sessionBus().unregisterObject(COMM_HISTORY_OBJECT_PATH);
+    QDBusConnection::sessionBus().unregisterService(m_serviceName);
 }
 
 QSharedPointer<UpdatesEmitter> UpdatesEmitter::instance()


### PR DESCRIPTION
Having a well-known service name attached to the
object when doing a database modification allows
to filter/enable it with Firejail.

@pvuorela, I believe [this issue](https://forum.sailfishos.org/t/removing-entries-from-call-history-programmatically/17909) comes from a Firejail filtering. It's working when the voicecall-ui is launched from the command-line, but not through Sailjail. In the log, there is this issue :
```
B6: <- :1.798 signal com.nokia.commhistory.eventDeleted at /CommHistoryModel
*FILTERED IN*
```

This comes from the fact that the sender is not a well-known service (it's :1.798) and talk and broadcast rules only apply to weel-known service names. The issue is not showing up for addition in the call history for instance, I guess because the event is coming from the voicecall-managerd which owns a well-known service on D-Bus. While, running `commhistory-tool` from the command-line does not own any well-known names.

The solution I'm proposing is to give a well-known name to any process emitting using the com.nokia.commhistory interface.

It also requires to whitelist this new well-known service name in sailjail (see my PR there).