### PR TITLE
[libcommhistory] Fix registering service name. JB#62605

### DIFF
--- a/src/updatesemitter.cpp
+++ b/src/updatesemitter.cpp
@@ -42,8 +42,9 @@ UpdatesEmitter::UpdatesEmitter()
         qCWarning(lcCommHistory) << Q_FUNC_INFO << ": error registering object";
     }
     m_serviceName
-        = QString::fromLatin1("%1.p%2").arg(COMM_HISTORY_SERVICE_NAME_PREFIX,
-                                            QCoreApplication::applicationPid());
+        = QString::fromLatin1("%1.p%2")
+            .arg(COMM_HISTORY_SERVICE_NAME_PREFIX)
+            .arg(QCoreApplication::applicationPid());
     if (!QDBusConnection::sessionBus().registerService(m_serviceName)) {
         qCWarning(lcCommHistory) << Q_FUNC_INFO << ": error registering service"
                                  << QDBusConnection::sessionBus().lastError();


### PR DESCRIPTION
QString::arg() to replace multiple placeholders requires all parameters to be QString. Here it wasn't doing the expected thing. No fear in having %2 in commhistory prefix so just using separate arg()s.

cc @dcaliste 