### PR TITLE
Adjust mms id type

### DIFF
--- a/declarative/src/callproxymodel.cpp
+++ b/declarative/src/callproxymodel.cpp
@@ -5,13 +5,13 @@
 
 using namespace CommHistory;
 
-CallProxyModel::CallProxyModel(QObject *parent) :
-    CommHistory::CallModel(parent),
-    m_grouping(GroupByNone),
-    m_limit(0),
-    m_resolveContacts(false),
-    m_componentComplete(false),
-    m_populated(false)
+CallProxyModel::CallProxyModel(QObject *parent)
+    : CommHistory::CallModel(parent)
+    , m_grouping(GroupByNone)
+    , m_limit(0)
+    , m_resolveContacts(false)
+    , m_componentComplete(false)
+    , m_populated(false)
 {
     setQueryMode(CommHistory::EventModel::AsyncQuery);
     setFilter(CommHistory::CallModel::Sorting(m_grouping));

--- a/declarative/src/constants.h
+++ b/declarative/src/constants.h
@@ -99,4 +99,3 @@ public:
 };
 
 #endif
-

--- a/declarative/src/conversationproxymodel.cpp
+++ b/declarative/src/conversationproxymodel.cpp
@@ -36,7 +36,9 @@
 using namespace CommHistory;
 
 ConversationProxyModel::ConversationProxyModel(QObject *parent)
-    : ConversationModel(parent), m_contactGroup(0), m_groupId(-1) 
+    : ConversationModel(parent)
+    , m_contactGroup(nullptr)
+    , m_groupId(-1)
 {
     // Defaults
     setQueryMode(EventModel::StreamedAsyncQuery);
@@ -95,7 +97,7 @@ void ConversationProxyModel::setGroupId(int g)
     if (m_contactGroup)
         setContactGroup(0);
     else
-        QTimer::singleShot(0, this, SLOT(reload()));
+        QTimer::singleShot(0, this, &ConversationProxyModel::reload);
 }
 
 bool ConversationProxyModel::resolveContacts() const
@@ -131,4 +133,3 @@ void ConversationProxyModel::reload()
         getEvents(QList<int>());
     }
 }
-

--- a/declarative/src/conversationproxymodel.h
+++ b/declarative/src/conversationproxymodel.h
@@ -34,6 +34,7 @@
 
 #include <QIdentityProxyModel>
 #include <QHash>
+
 #include "conversationmodel.h"
 #include "sharedbackgroundthread.h"
 #include "contactgroup.h"
@@ -47,7 +48,7 @@ class ConversationProxyModel : public CommHistory::ConversationModel
     Q_PROPERTY(bool resolveContacts READ resolveContacts WRITE setResolveContacts NOTIFY resolveContactsChanged)
 
 public:
-    ConversationProxyModel(QObject *parent = 0);
+    ConversationProxyModel(QObject *parent = nullptr);
 
     CommHistory::ContactGroup *contactGroup() const { return m_contactGroup; }
     void setContactGroup(QObject *group);

--- a/declarative/src/declarativegroupmanager.cpp
+++ b/declarative/src/declarativegroupmanager.cpp
@@ -32,8 +32,9 @@
 #include "declarativegroupmanager.h"
 #include "sharedbackgroundthread.h"
 #include "singleeventmodel.h"
-#include <QTimer>
 #include "debug.h"
+
+#include <QTimer>
 
 using namespace CommHistory;
 
@@ -243,4 +244,3 @@ int DeclarativeGroupManager::ensureGroupExists(const QString &localUid, const QS
 }
 
 #include "declarativegroupmanager.moc"
-

--- a/declarative/src/declarativegroupmanager.h
+++ b/declarative/src/declarativegroupmanager.h
@@ -40,12 +40,11 @@
 class DeclarativeGroupManager : public CommHistory::GroupManager
 {
     Q_OBJECT
-
     Q_PROPERTY(bool useBackgroundThread READ useBackgroundThread WRITE setUseBackgroundThread NOTIFY backgroundThreadChanged)
     Q_PROPERTY(bool resolveContacts READ resolveContacts WRITE setResolveContacts NOTIFY resolveContactsChanged)
 
 public:
-    DeclarativeGroupManager(QObject *parent = 0);
+    DeclarativeGroupManager(QObject *parent = nullptr);
     virtual ~DeclarativeGroupManager();
 
     bool useBackgroundThread() { return backgroundThread() != 0; }
@@ -62,8 +61,10 @@ public:
      *
      * If groupId is negative, an appropriate group will be found or created
      * inline if necessary. */
-    Q_INVOKABLE int createOutgoingMessageEvent(int groupId, const QString &localUid, const QString &remoteUid, const QString &text);
-    Q_INVOKABLE int createOutgoingMessageEvent(int groupId, const QString &localUid, const QStringList &remoteUids, const QString &text);
+    Q_INVOKABLE int createOutgoingMessageEvent(int groupId, const QString &localUid, const QString &remoteUid,
+                                               const QString &text);
+    Q_INVOKABLE int createOutgoingMessageEvent(int groupId, const QString &localUid, const QStringList &remoteUids,
+                                               const QString &text);
 
     /* Create an event for an outgoing plain text message, which will be
      * in the sending state. The event ID will be passed to the callback
@@ -73,8 +74,10 @@ public:
      *
      * If groupId is negative, an appropriate group will be found or created
      * inline if necessary. */
-    Q_INVOKABLE void createOutgoingMessageEvent(int groupId, const QString &localUid, const QString &remoteUid, const QString &text, QJSValue callback);
-    Q_INVOKABLE void createOutgoingMessageEvent(int groupId, const QString &localUid, const QStringList &remoteUids, const QString &text, QJSValue callback);
+    Q_INVOKABLE void createOutgoingMessageEvent(int groupId, const QString &localUid, const QString &remoteUid,
+                                                const QString &text, QJSValue callback);
+    Q_INVOKABLE void createOutgoingMessageEvent(int groupId, const QString &localUid, const QStringList &remoteUids,
+                                                const QString &text, QJSValue callback);
 
     Q_INVOKABLE bool setEventStatus(int eventId, int status);
 
@@ -95,4 +98,3 @@ private:
 };
 
 #endif
-

--- a/declarative/src/declarativerecipienteventmodel.h
+++ b/declarative/src/declarativerecipienteventmodel.h
@@ -47,7 +47,7 @@ class DeclarativeRecipientEventModel : public CommHistory::RecipientEventModel, 
     Q_PROPERTY(QString remoteUid READ remoteUid WRITE setRemoteUid NOTIFY remoteUidChanged)
 
 public:
-    DeclarativeRecipientEventModel(QObject *parent = 0);
+    DeclarativeRecipientEventModel(QObject *parent = nullptr);
 
     int contactId() const;
     void setContactId(int contactId);

--- a/declarative/src/draftevent.cpp
+++ b/declarative/src/draftevent.cpp
@@ -189,10 +189,10 @@ bool DraftEvent::isModified() const
 
 bool DraftEvent::isValid() const
 {
-    return !m_event.localUid().isEmpty() &&
-           !m_event.recipients().isEmpty() &&
-           !m_event.freeText().isEmpty() &&
-           m_event.groupId() >= 0;
+    return !m_event.localUid().isEmpty()
+            && !m_event.recipients().isEmpty()
+            && !m_event.freeText().isEmpty()
+            && m_event.groupId() >= 0;
 }
 
 bool DraftEvent::load(int eventId)
@@ -207,4 +207,3 @@ bool DraftEvent::load(int eventId)
 
     return false;
 }
-

--- a/declarative/src/draftevent.h
+++ b/declarative/src/draftevent.h
@@ -49,7 +49,7 @@ class DraftEvent : public QObject
     Q_PROPERTY(bool isValid READ isValid NOTIFY isValidChanged)
 
 public:
-    DraftEvent(QObject *parent = 0);
+    DraftEvent(QObject *parent = nullptr);
     ~DraftEvent();
 
     CommHistory::Event event() const;

--- a/declarative/src/mmshelper.cpp
+++ b/declarative/src/mmshelper.cpp
@@ -33,6 +33,7 @@
 #include "mmsconstants.h"
 #include "singleeventmodel.h"
 #include "debug.h"
+
 #include <QtDBus>
 #include <QTextCodec>
 #include <QTemporaryDir>
@@ -72,7 +73,8 @@ using namespace CommHistory;
 
 // QObject wrapper around QTemporaryDir to keep the temporary directory around
 // until the D-Bus call completes
-class MmsHelper::TempDir : public QObject {
+class MmsHelper::TempDir : public QObject
+{
     Q_OBJECT
 
 public:
@@ -218,7 +220,8 @@ static QString createTemporaryFile(const QString &dir, const QString &source)
     return targetFile;
 }
 
-bool MmsHelper::sendMessage(const QStringList &to, const QStringList &cc, const QStringList &bcc, const QString &subject, const QVariantList &parts)
+bool MmsHelper::sendMessage(const QStringList &to, const QStringList &cc, const QStringList &bcc,
+                            const QString &subject, const QVariantList &parts)
 {
     return sendMessage(QString(), to, cc, bcc, subject, parts);
 }

--- a/declarative/src/mmshelper.h
+++ b/declarative/src/mmshelper.h
@@ -48,13 +48,16 @@ public:
 public slots:
     bool receiveMessage(int id);
     bool cancel(int id);
-    bool sendMessage(const QStringList &to, const QStringList &cc, const QStringList &bcc, const QString &subject, const QVariantList &parts);
-    bool sendMessage(const QString &imsi, const QStringList &to, const QStringList &cc, const QStringList &bcc, const QString &subject, const QVariantList &parts);
+    bool sendMessage(const QStringList &to, const QStringList &cc, const QStringList &bcc, const QString &subject,
+                     const QVariantList &parts);
+    bool sendMessage(const QString &imsi, const QStringList &to, const QStringList &cc, const QStringList &bcc,
+                     const QString &subject, const QVariantList &parts);
     bool retrySendMessage(int id);
 
 private:
-    class TempDir;
     static void callEngine(const QString &method, const QVariantList &args);
+
+    class TempDir;
     QDBusPendingCallWatcher *sendMessage(const TempDir &tempDir, const QString &imsi,
         const QStringList &to, const QStringList &cc, const QStringList &bcc,
         const QString &subject, const QVariantList &parts);

--- a/src/callmodel.cpp
+++ b/src/callmodel.cpp
@@ -1178,10 +1178,9 @@ bool CallModel::deleteEvent(int id)
             return true;
         }
         default:
-        {
-            qCWarning(lcCommHistory) << Q_FUNC_INFO << "Deleting of call events from model sorted by type or by service has not been implemented yet.";
+            qCWarning(lcCommHistory) << Q_FUNC_INFO
+                                     << "Deleting of call events from model sorted by type or by service has not been implemented yet.";
             return false;
-        }
     }
 }
 

--- a/src/commhistorydatabase.cpp
+++ b/src/commhistorydatabase.cpp
@@ -23,6 +23,7 @@
 #include "commhistorydatabase.h"
 #include "commhistorydatabasepath.h"
 #include "debug_p.h"
+
 #include <QDir>
 #include <QFile>
 #include <QSqlError>

--- a/src/commhistorydatabase.cpp
+++ b/src/commhistorydatabase.cpp
@@ -87,7 +87,7 @@ static const char *db_schema[] = {
     "  readStatus INTEGER, "
     "  reportRead INTEGER, "
     "  reportedReadRequested INTEGER, "
-    "  mmsId INTEGER, "
+    "  mmsId TEXT, " // was INTEGER for over 10 years. changed without migration as it clearly worked good enough
     "  isAction INTEGER, "
     "  hasExtraProperties BOOL DEFAULT 0, "
     "  hasMessageParts BOOL DEFAULT 0, "

--- a/src/contactgroup.cpp
+++ b/src/contactgroup.cpp
@@ -500,6 +500,5 @@ GroupObject *ContactGroup::findGroup(const QString &localUid, const QStringList 
             return g;
     }
 
-    return 0;
+    return nullptr;
 }
-

--- a/src/contactgroupmodel.cpp
+++ b/src/contactgroupmodel.cpp
@@ -455,4 +455,3 @@ void ContactGroupModel::fetchMore(const QModelIndex &parent)
 }
 
 #include "contactgroupmodel.moc"
-

--- a/src/contactgroupmodel.h
+++ b/src/contactgroupmodel.h
@@ -112,11 +112,11 @@ public:
     QList<QObject*> contactGroups() const;
 
     /* reimp */
-    virtual bool canFetchMore(const QModelIndex &parent) const;
-    virtual void fetchMore(const QModelIndex &parent);
-    virtual int rowCount(const QModelIndex &parent = QModelIndex()) const;
-    virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
-    virtual QHash<int,QByteArray> roleNames() const;
+    bool canFetchMore(const QModelIndex &parent) const override;
+    void fetchMore(const QModelIndex &parent) override;
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QHash<int,QByteArray> roleNames() const override;
     /***/
 
 Q_SIGNALS:

--- a/src/contactlistener.cpp
+++ b/src/contactlistener.cpp
@@ -234,4 +234,3 @@ void ContactListenerPrivate::itemAboutToBeRemoved(SeasideCache::CacheItem *item)
 }
 
 #include "contactlistener.moc"
-

--- a/src/conversationmodel.cpp
+++ b/src/conversationmodel.cpp
@@ -33,13 +33,14 @@
 #include "debug_p.h"
 
 namespace {
-static CommHistory::Event::PropertySet unusedProperties = CommHistory::Event::PropertySet()
+CommHistory::Event::PropertySet unusedProperties = CommHistory::Event::PropertySet()
                                              << CommHistory::Event::IsDraft
                                              << CommHistory::Event::IsMissedCall
                                              << CommHistory::Event::IsEmergencyCall
                                              << CommHistory::Event::BytesReceived
                                              << CommHistory::Event::EventCount;
 }
+
 namespace CommHistory {
 
 ConversationModelPrivate::ConversationModelPrivate(EventModel *model)

--- a/src/databaseio.cpp
+++ b/src/databaseio.cpp
@@ -25,9 +25,10 @@
 #include "commhistorydatabase.h"
 #include "contactlistener.h"
 #include "group.h"
+#include "debug_p.h"
+
 #include <QSqlQuery>
 #include <QSqlError>
-#include "debug_p.h"
 
 using namespace CommHistory;
 
@@ -790,8 +791,8 @@ bool DatabaseIO::getEventByMmsId(const QString &mmsId, Event &event)
                 d->readEventResult(query, e, extra, parts);
                 query.finish();
 
-                if ((!extra || getEventExtraProperties(e)) &&
-                    (!parts || getMessageParts(e))) {
+                if ((!extra || getEventExtraProperties(e))
+                    && (!parts || getMessageParts(e))) {
                     ok = true;
                 }
             }

--- a/src/databaseio.h
+++ b/src/databaseio.h
@@ -47,6 +47,7 @@ class LIBCOMMHISTORY_EXPORT DatabaseIO : public QObject
 public:
     DatabaseIO();
     ~DatabaseIO();
+
     static DatabaseIO* instance();
 
     /*!

--- a/src/draftsmodel.cpp
+++ b/src/draftsmodel.cpp
@@ -110,4 +110,3 @@ bool DraftsModel::getEvents()
 }
 
 }
-

--- a/src/draftsmodel_p.h
+++ b/src/draftsmodel_p.h
@@ -25,6 +25,7 @@
 
 #include "eventmodel_p.h"
 #include "draftsmodel.h"
+
 #include <QSet>
 
 namespace CommHistory {

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1159,7 +1159,7 @@ QString Event::toString() const
 
 void Event::copyValidProperties(const Event &other)
 {
-    foreach(Property p, other.validProperties()) {
+    foreach (Property p, other.validProperties()) {
         switch (p) {
         case Id:
             setId(other.id());

--- a/src/eventmodel_p.cpp
+++ b/src/eventmodel_p.cpp
@@ -579,10 +579,10 @@ void EventModelPrivate::setResolveContacts(EventModel::ContactResolveType type)
         contactListener.clear();
 
         delete receiveResolver;
-        receiveResolver = 0;
+        receiveResolver = nullptr;
 
         delete onDemandResolver;
-        onDemandResolver = 0;
+        onDemandResolver = nullptr;
     }
 }
 
@@ -593,4 +593,3 @@ void EventModelPrivate::emitDataChanged(int row, void *data)
     const QModelIndex modelIndex(q->createIndex(row, 0, data));
     emit q->dataChanged(modelIndex, modelIndex);
 }
-

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -607,7 +607,7 @@ QString Group::toString() const
 
 void Group::copyValidProperties(const Group &other)
 {
-    foreach(Property p, other.validProperties()) {
+    foreach (Property p, other.validProperties()) {
         switch (p) {
         case Id:
             setId(other.id());

--- a/src/groupmodel.cpp
+++ b/src/groupmodel.cpp
@@ -198,7 +198,7 @@ QHash<int, QByteArray> GroupModel::roleNames() const
 GroupModel::~GroupModel()
 {
     delete d;
-    d = 0;
+    d = nullptr;
 }
 
 GroupManager *GroupModel::manager() const
@@ -449,4 +449,3 @@ void GroupModel::setResolveContacts(GroupManager::ContactResolveType type)
     d->ensureManager();
     d->manager->setResolveContacts(type);
 }
-

--- a/src/groupobject.cpp
+++ b/src/groupobject.cpp
@@ -590,4 +590,3 @@ void GroupObject::copyValidProperties(const Group &other)
 {
     ::copyValidProperties(other, *this);
 }
-

--- a/src/messagepart.cpp
+++ b/src/messagepart.cpp
@@ -187,16 +187,17 @@ QString MessagePart::plainTextContent() const
     }
 
     QByteArray content = file.readAll();
-
-    QTextCodec *codec = 0;
+    QTextCodec *codec = nullptr;
     int pos = d->contentType.indexOf(";charset=");
+
     if (pos > 0) {
         pos += strlen(";charset=");
         QStringRef charset = d->contentType.midRef(pos, d->contentType.indexOf(';', pos) - pos).trimmed();
 
         codec = QTextCodec::codecForName(charset.toLatin1());
         if (!codec)
-            qCWarning(lcCommHistory) << "Missing text codec for" << charset << "when parsing content of type" << d->contentType;
+            qCWarning(lcCommHistory) << "Missing text codec for" << charset
+                                     << "when parsing content of type" << d->contentType;
     }
 
     if (codec)

--- a/src/messagepart.h
+++ b/src/messagepart.h
@@ -61,8 +61,7 @@ public:
     /*!
      * Identifier for this part within an event, set externally.
      *
-     * For example, in a MMS message this is the content ID referenced
-     * in SMIL.
+     * For example, in an MMS message this is the content ID referenced in SMIL.
      */
     QString contentId() const;
     void setContentId(const QString &id);

--- a/src/mmsreadreportmodel.cpp
+++ b/src/mmsreadreportmodel.cpp
@@ -72,12 +72,12 @@ QSqlQuery MmsReadReportModel::Private::buildGroupQuery(int groupId)
 
 bool MmsReadReportModel::acceptsEvent(const Event &event)
 {
-    return (event.type() == Event::MMSEvent &&
-            event.direction() == Event::Inbound &&
-            event.isRead() &&
-            event.reportRead() &&
-            !event.mmsId().isEmpty() &&
-            !event.extraProperty(MMS_PROPERTY_UNREAD).toString().isEmpty());
+    return (event.type() == Event::MMSEvent
+            && event.direction() == Event::Inbound
+            && event.isRead()
+            && event.reportRead()
+            && !event.mmsId().isEmpty()
+            && !event.extraProperty(MMS_PROPERTY_UNREAD).toString().isEmpty());
 }
 
 MmsReadReportModel::MmsReadReportModel(QObject *parent) : EventModel(parent), d(NULL)

--- a/src/recentcontactsmodel.h
+++ b/src/recentcontactsmodel.h
@@ -38,7 +38,6 @@ class RecentContactsModelPrivate;
 class LIBCOMMHISTORY_EXPORT RecentContactsModel : public EventModel
 {
     Q_OBJECT
-
     Q_PROPERTY(int requiredProperty READ requiredProperty WRITE setRequiredProperty NOTIFY requiredPropertyChanged)
     Q_PROPERTY(bool excludeFavorites READ excludeFavorites WRITE setExcludeFavorites NOTIFY excludeFavoritesChanged)
     Q_PROPERTY(bool resolving READ resolving NOTIFY resolvingChanged)

--- a/src/recipient.cpp
+++ b/src/recipient.cpp
@@ -123,7 +123,7 @@ Recipient::~Recipient()
 RecipientPrivate::RecipientPrivate(const QString &local, const QString &remote)
     : localUid(local)
     , remoteUid(remote)
-    , item(0)
+    , item(nullptr)
     , isResolved(false)
     , isPhoneNumber(localUidComparesPhoneNumbers(localUid))
     // The following members could be initialized on-demand, but that appears to be slower overall
@@ -328,7 +328,7 @@ void Recipient::setUnresolved() const
         recipientContactMap->remove(d->item->iid, d);
 
     d->isResolved = false;
-    d->item = 0;
+    d->item = nullptr;
     d->contactNameHash = 0;
     d->addressFlags = 0;
 }
@@ -781,4 +781,3 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, CommHistory::Reci
     argument.endArray();
     return argument;
 }
-

--- a/src/singleeventmodel.cpp
+++ b/src/singleeventmodel.cpp
@@ -36,19 +36,21 @@ namespace CommHistory {
 
 using namespace CommHistory;
 
-class SingleEventModelPrivate : public EventModelPrivate {
+class SingleEventModelPrivate : public EventModelPrivate
+{
 public:
     Q_DECLARE_PUBLIC(SingleEventModel)
 
     SingleEventModelPrivate(EventModel *model)
-        : EventModelPrivate(model) {
+        : EventModelPrivate(model)
+    {
         queryLimit = 1;
         m_eventId = -1;
         clearTokens();
     }
 
-    bool acceptsEvent(const Event &event) const {
-
+    bool acceptsEvent(const Event &event) const
+    {
         // If the urls match, we'll accept
         if (m_eventId >= 0 && event.id() == m_eventId)
             return true;
@@ -60,11 +62,12 @@ public:
         }
 
         // Accept the event if message tokens or mmsIds match
-        return (!m_token.isEmpty() && m_token == event.messageToken()) ||
-               (!m_mmsId.isEmpty() && m_mmsId == event.mmsId());
+        return (!m_token.isEmpty() && m_token == event.messageToken())
+               || (!m_mmsId.isEmpty() && m_mmsId == event.mmsId());
     }
 
-    void clearTokens() {
+    void clearTokens()
+    {
         m_token.clear();
         m_mmsId.clear();
         m_groupId = -1;
@@ -153,6 +156,5 @@ Event SingleEventModel::event() const
 {
     return EventModel::event(index(0, 0));
 }
-
 
 } // namespace CommHistory

--- a/src/singleeventmodel.h
+++ b/src/singleeventmodel.h
@@ -46,7 +46,7 @@ public:
      *
      * \param parent Parent object.
      */
-    explicit SingleEventModel(QObject *parent = 0);
+    explicit SingleEventModel(QObject *parent = nullptr);
 
     /*!
      * Destructor.

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -590,7 +590,7 @@ QString randomMessage(int words)
 {
     QString msg;
     QTextStream msgStream(&msg, QIODevice::WriteOnly);
-    for(int j = 0; j < words; j++) {
+    for (int j = 0; j < words; j++) {
         msgStream << msgWords[qrand() % numWords] << " ";
     }
     return msg;
@@ -639,4 +639,3 @@ void summarizeResults(const QString &className, QList<int> &times, QFile *logFil
             << "\n";
     }
 }
-

--- a/tests/mem_eventmodel/mem_eventmodel.cpp
+++ b/tests/mem_eventmodel/mem_eventmodel.cpp
@@ -37,7 +37,7 @@ Group group;
 #define WAIT_TIMEOUT 30000
 #define CALM_TIMEOUT 500
 
-#define MALLINFO_DUMP(s) {struct mallinfo m = mallinfo();qDebug() << "MALLINFO" << (s) << m.arena << m.uordblks << m.fordblks;}
+#define MALLINFO_DUMP(s) {struct mallinfo2 m = mallinfo2();qDebug() << "MALLINFO" << (s) << m.arena << m.uordblks << m.fordblks;}
 
 static void waitWithDeletes(int msec)
 {

--- a/tests/mem_eventmodel/mem_eventmodel.cpp
+++ b/tests/mem_eventmodel/mem_eventmodel.cpp
@@ -217,8 +217,7 @@ void MemEventModelTest::callSetFilter()
     QTRY_COMPARE(ready.count(), expectedReadyCount);
     expectedReadyCount++;
 
-    for(int i = 0; i < 5; i++) {
-
+    for (int i = 0; i < 5; i++) {
         if (i&1)
             model->setFilter(CallModel::SortByTime, CommHistory::CallEvent::MissedCallType);
         else

--- a/tests/perf_callmodel/callmodelperftest.cpp
+++ b/tests/perf_callmodel/callmodelperftest.cpp
@@ -35,9 +35,9 @@ void CallModelPerfTest::initTestCase()
     initTestDatabase();
 
     logFile = new QFile("libcommhistory-performance-test.log");
-    if(!logFile->open(QIODevice::Append)) {
+    if (!logFile->open(QIODevice::Append)) {
         qDebug() << "!!!! Failed to open log file !!!!";
-        logFile = 0;
+        logFile = nullptr;
     }
 
     qsrand( QDateTime::currentDateTime().toTime_t() );
@@ -105,7 +105,7 @@ void CallModelPerfTest::getEvents()
     QList<QPair<QString, QPair<QString, QString> > > contactDetails;
 
     int ci = remoteUids.count();
-    while(ci < contacts) {
+    while (ci < contacts) {
         QString phoneNumber;
         do {
             phoneNumber = QString().setNum(qrand() % 10000000);
@@ -116,7 +116,7 @@ void CallModelPerfTest::getEvents()
 
         contactDetails.append(qMakePair(QString("Test Contact %1").arg(ci), qMakePair(phoneNumber, QString())));
 
-        if(ci % commitBatchSize == 0 && ci < contacts) {
+        if (ci % commitBatchSize == 0 && ci < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "contacts (" << ci << "/" << contacts << ")";
             addTestContacts(contactDetails);
@@ -138,13 +138,13 @@ void CallModelPerfTest::getEvents()
     random_shuffle(contactIndices.begin(), contactIndices.end());
 
     int ei = 0;
-    while(ei < events) {
+    while (ei < events) {
         ei++;
 
         Event::EventDirection direction;
         bool isMissed = false;
 
-        if(qrand() % 2 > 0) {
+        if (qrand() % 2 > 0) {
             direction = Event::Inbound;
             isMissed = (qrand() % 2 > 0);
         } else {
@@ -165,7 +165,7 @@ void CallModelPerfTest::getEvents()
 
         eventList << e;
 
-        if(ei % commitBatchSize == 0 && ei != events) {
+        if (ei % commitBatchSize == 0 && ei != events) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "events (" << ei << "/" << events << ")";
             QVERIFY(addModel.addEvents(eventList, false));
@@ -194,7 +194,7 @@ void CallModelPerfTest::getEvents()
     }
 
     qDebug() << Q_FUNC_INFO << "- Fetching events." << iterations << "iterations";
-    for(int i = 0; i < iterations; i++) {
+    for (int i = 0; i < iterations; i++) {
 
         CallModel fetchModel;
 
@@ -222,10 +222,10 @@ void CallModelPerfTest::getEvents()
 
 void CallModelPerfTest::cleanupTestCase()
 {
-    if(logFile) {
+    if (logFile) {
         logFile->close();
         delete logFile;
-        logFile = 0;
+        logFile = nullptr;
     }
 
     deleteAll();

--- a/tests/perf_conversationmodel/conversationmodelperftest.cpp
+++ b/tests/perf_conversationmodel/conversationmodelperftest.cpp
@@ -36,9 +36,9 @@ void ConversationModelPerfTest::initTestCase()
     initTestDatabase();
 
     logFile = new QFile("libcommhistory-performance-test.log");
-    if(!logFile->open(QIODevice::Append)) {
+    if (!logFile->open(QIODevice::Append)) {
         qDebug() << "!!!! Failed to open log file !!!!";
-        logFile = 0;
+        logFile = nullptr;
     }
 
     qsrand( QDateTime::currentDateTime().toTime_t() );
@@ -104,7 +104,7 @@ void ConversationModelPerfTest::getEvents()
     QList<QPair<QString, QPair<QString, QString> > > contactDetails;
 
     int ci = remoteUids.count();
-    while(ci < contacts) {
+    while (ci < contacts) {
         QString phoneNumber;
         do {
             phoneNumber = QString().setNum(qrand() % 10000000);
@@ -115,7 +115,7 @@ void ConversationModelPerfTest::getEvents()
 
         contactDetails.append(qMakePair(QString("Test Contact %1").arg(ci), qMakePair(phoneNumber, QString())));
 
-        if(ci % commitBatchSize == 0 && ci < contacts) {
+        if (ci % commitBatchSize == 0 && ci < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "contacts (" << ci << "/" << contacts << ")";
             addTestContacts(contactDetails);
@@ -140,7 +140,7 @@ void ConversationModelPerfTest::getEvents()
     GroupModel groupModel;
 
     int gi = 0;
-    while(gi < contacts) {
+    while (gi < contacts) {
         Group grp;
         grp.setLocalUid(RING_ACCOUNT);
         grp.setRecipients(RecipientList::fromPhoneNumbers(QStringList() << remoteUids.at(contactIndices.at(gi))));
@@ -150,7 +150,7 @@ void ConversationModelPerfTest::getEvents()
         groupIds << grp.id();
 
         gi++;
-        if(gi % commitBatchSize == 0 && gi < contacts) {
+        if (gi % commitBatchSize == 0 && gi < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "groups (" << gi << "/" << contacts << ")";
         }
@@ -166,7 +166,7 @@ void ConversationModelPerfTest::getEvents()
     QList<Event> eventList;
 
     int ei = 0;
-    while(ei < messages) {
+    while (ei < messages) {
         ei++;
 
         Event::EventDirection direction;
@@ -188,7 +188,7 @@ void ConversationModelPerfTest::getEvents()
 
         eventList << e;
 
-        if(ei % commitBatchSize == 0 && ei != messages) {
+        if (ei % commitBatchSize == 0 && ei != messages) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "messages (" << ei << "/" << messages << ")";
             QVERIFY(addModel.addEvents(eventList, false));
@@ -217,8 +217,7 @@ void ConversationModelPerfTest::getEvents()
     }
 
     qDebug() << Q_FUNC_INFO << "- Fetching messages." << iterations << "iterations";
-    for(int i = 0; i < iterations; i++) {
-
+    for (int i = 0; i < iterations; i++) {
         ConversationModel fetchModel;
         fetchModel.setResolveContacts(resolve ? EventModel::ResolveImmediately : EventModel::DoNotResolve);
 
@@ -248,10 +247,10 @@ void ConversationModelPerfTest::getEvents()
 
 void ConversationModelPerfTest::cleanupTestCase()
 {
-    if(logFile) {
+    if (logFile) {
         logFile->close();
         delete logFile;
-        logFile = 0;
+        logFile = nullptr;
     }
 
     deleteAll();

--- a/tests/perf_groupmodel/groupmodelperftest.cpp
+++ b/tests/perf_groupmodel/groupmodelperftest.cpp
@@ -36,9 +36,9 @@ void GroupModelPerfTest::initTestCase()
     initTestDatabase();
 
     logFile = new QFile("libcommhistory-performance-test.log");
-    if(!logFile->open(QIODevice::Append)) {
+    if (!logFile->open(QIODevice::Append)) {
         qDebug() << "!!!! Failed to open log file !!!!";
-        logFile = 0;
+        logFile = nullptr;
     }
 
     qsrand( QDateTime::currentDateTime().toTime_t() );
@@ -108,7 +108,7 @@ void GroupModelPerfTest::getGroups()
     QList<QPair<QString, QPair<QString, QString> > > contactDetails;
 
     int ci = remoteUids.count();
-    while(ci < contacts) {
+    while (ci < contacts) {
         QString phoneNumber;
         do {
             phoneNumber = QString().setNum(qrand() % 10000000);
@@ -119,7 +119,7 @@ void GroupModelPerfTest::getGroups()
 
         contactDetails.append(qMakePair(QString("Test Contact %1").arg(ci), qMakePair(phoneNumber, QString())));
 
-        if(ci % commitBatchSize == 0 && ci < contacts) {
+        if (ci % commitBatchSize == 0 && ci < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "contacts (" << ci << "/" << contacts << ")";
             addTestContacts(contactDetails);
@@ -141,7 +141,7 @@ void GroupModelPerfTest::getGroups()
     QList<Group> groupList;
 
     int gi = 0;
-    while(gi < groups) {
+    while (gi < groups) {
         Group grp;
         grp.setLocalUid(RING_ACCOUNT);
         grp.setRecipients(RecipientList::fromPhoneNumbers(QStringList() << remoteUids.at(contactIndices.at(gi))));
@@ -150,7 +150,7 @@ void GroupModelPerfTest::getGroups()
         groupList << grp;
 
         gi++;
-        if(gi % commitBatchSize == 0 && gi < groups) {
+        if (gi % commitBatchSize == 0 && gi < groups) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "groups (" << gi << "/" << groups << ")";
         }
@@ -165,8 +165,8 @@ void GroupModelPerfTest::getGroups()
     gi = 0;
     foreach (Group grp, groupList) {
         QList<Event> eventList;
-        for(int i = 0; i < messages; i++) {
 
+        for (int i = 0; i < messages; i++) {
             Event e;
             e.setType(Event::SMSEvent);
             e.setDirection(qrand() % 2 ? Event::Inbound : Event::Outbound);
@@ -205,8 +205,7 @@ void GroupModelPerfTest::getGroups()
     }
 
     qDebug() << Q_FUNC_INFO << "- Fetching groups." << iterations << "iterations";
-    for(int i = 0; i < iterations; i++) {
-
+    for (int i = 0; i < iterations; i++) {
         GroupModel fetchModel;
 
         GroupManager manager;
@@ -234,10 +233,10 @@ void GroupModelPerfTest::getGroups()
 
 void GroupModelPerfTest::cleanupTestCase()
 {
-    if(logFile) {
+    if (logFile) {
         logFile->close();
         delete logFile;
-        logFile = 0;
+        logFile = nullptr;
     }
 
     deleteAll();

--- a/tests/perf_recentcontactsmodel/recentcontactsmodelperftest.cpp
+++ b/tests/perf_recentcontactsmodel/recentcontactsmodelperftest.cpp
@@ -36,9 +36,9 @@ void RecentContactsModelPerfTest::initTestCase()
     initTestDatabase();
 
     logFile = new QFile("libcommhistory-performance-test.log");
-    if(!logFile->open(QIODevice::Append)) {
+    if (!logFile->open(QIODevice::Append)) {
         qDebug() << "!!!! Failed to open log file !!!!";
-        logFile = 0;
+        logFile = nullptr;
     }
 
     qsrand( QDateTime::currentDateTime().toTime_t() );
@@ -93,7 +93,7 @@ void RecentContactsModelPerfTest::getEvents()
     QList<QPair<QString, QPair<QString, QString> > > contactDetails;
 
     int ci = remoteUids.count();
-    while(ci < contacts) {
+    while (ci < contacts) {
         QString phoneNumber;
         do {
             phoneNumber = QString().setNum(qrand() % 10000000);
@@ -104,7 +104,7 @@ void RecentContactsModelPerfTest::getEvents()
 
         contactDetails.append(qMakePair(QString("Test Contact %1").arg(ci), qMakePair(phoneNumber, (ci <= groups ? ACCOUNT1 : QString()))));
 
-        if(ci % commitBatchSize == 0 && ci < contacts) {
+        if (ci % commitBatchSize == 0 && ci < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "contacts (" << ci << "/" << contacts << ")";
             addTestContacts(contactDetails);
@@ -124,7 +124,7 @@ void RecentContactsModelPerfTest::getEvents()
     QList<Group> groupList;
 
     int gi = 0;
-    while(gi < groups) {
+    while (gi < groups) {
         Group grp;
         grp.setLocalUid(ACCOUNT1);
         grp.setRecipients(RecipientList::fromUids(ACCOUNT1, QStringList() << remoteUids.at(contactIndices.at(gi))));
@@ -133,7 +133,7 @@ void RecentContactsModelPerfTest::getEvents()
         groupList << grp;
 
         gi++;
-        if(gi % commitBatchSize == 0 && gi < groups) {
+        if (gi % commitBatchSize == 0 && gi < groups) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "groups (" << gi << "/" << groups << ")";
         }
@@ -146,7 +146,7 @@ void RecentContactsModelPerfTest::getEvents()
     QList<Event> eventList;
 
     int ei = 0;
-    while(ei < events) {
+    while (ei < events) {
         ei++;
 
         int idIndex = contactIndices.at(qrand() % contacts);
@@ -168,7 +168,7 @@ void RecentContactsModelPerfTest::getEvents()
 
         eventList << e;
 
-        if(ei % commitBatchSize == 0 && ei != events) {
+        if (ei % commitBatchSize == 0 && ei != events) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "events (" << ei << "/" << events << ")";
             QVERIFY(addModel.addEvents(eventList, false));
@@ -197,8 +197,8 @@ void RecentContactsModelPerfTest::getEvents()
     }
 
     qDebug() << Q_FUNC_INFO << "- Fetching events." << iterations << "iterations";
-    for(int i = 0; i < iterations; i++) {
 
+    for (int i = 0; i < iterations; i++) {
         RecentContactsModel fetchModel;
         if (limit)
             fetchModel.setLimit(limit);
@@ -224,10 +224,10 @@ void RecentContactsModelPerfTest::getEvents()
 
 void RecentContactsModelPerfTest::cleanupTestCase()
 {
-    if(logFile) {
+    if (logFile) {
         logFile->close();
         delete logFile;
-        logFile = 0;
+        logFile = nullptr;
     }
 
     deleteAll();

--- a/tests/profile_callmodel/callmodelprofiletest.cpp
+++ b/tests/profile_callmodel/callmodelprofiletest.cpp
@@ -36,7 +36,7 @@ void CallModelProfileTest::initTestCase()
 {
     initTestDatabase();
 
-    logFile = 0;
+    logFile = nullptr;
 
     qsrand( QDateTime::currentDateTime().toTime_t() );
 }
@@ -63,7 +63,7 @@ void CallModelProfileTest::prepare()
     QList<QPair<QString, QPair<QString, QString> > > contactDetails;
 
     int ci = remoteUids.count();
-    while(ci < contacts) {
+    while (ci < contacts) {
         QString phoneNumber;
         do {
             phoneNumber = QString().setNum(qrand() % 10000000);
@@ -74,7 +74,7 @@ void CallModelProfileTest::prepare()
 
         contactDetails.append(qMakePair(QString("Test Contact %1").arg(ci), qMakePair(phoneNumber, QString())));
 
-        if(ci % commitBatchSize == 0 && ci < contacts) {
+        if (ci % commitBatchSize == 0 && ci < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "contacts (" << ci << "/" << contacts << ")";
             addTestContacts(contactDetails);
@@ -96,13 +96,13 @@ void CallModelProfileTest::prepare()
     QList<Event> eventList;
 
     int ei = 0;
-    while(ei < events) {
+    while (ei < events) {
         ei++;
 
         Event::EventDirection direction;
         bool isMissed = false;
 
-        if(qrand() % 2 > 0) {
+        if (qrand() % 2 > 0) {
             direction = Event::Inbound;
             isMissed = (qrand() % 2 > 0);
         } else {
@@ -123,7 +123,7 @@ void CallModelProfileTest::prepare()
 
         eventList << e;
 
-        if(ei % commitBatchSize == 0 && ei != events) {
+        if (ei % commitBatchSize == 0 && ei != events) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "events (" << ei << "/" << events << ")";
             QVERIFY(addModel.addEvents(eventList, false));
@@ -146,16 +146,16 @@ void CallModelProfileTest::execute()
     int iterations = 1;
 
     logFile = new QFile("libcommhistory-performance-test.log");
-    if(!logFile->open(QIODevice::Append)) {
+    if (!logFile->open(QIODevice::Append)) {
         qDebug() << "!!!! Failed to open log file !!!!";
-        logFile = 0;
+        logFile = nullptr;
     }
 
     QDateTime startTime = QDateTime::currentDateTime();
 
     qDebug() << Q_FUNC_INFO << "- Fetching events." << iterations << "iterations";
-    for(int i = 0; i < iterations; i++) {
 
+    for (int i = 0; i < iterations; i++) {
         CallModel fetchModel;
 
         fetchModel.setResolveContacts(resolve ? EventModel::ResolveImmediately : EventModel::DoNotResolve);
@@ -190,7 +190,7 @@ void CallModelProfileTest::cleanupTestCase()
     if (logFile) {
         logFile->close();
         delete logFile;
-        logFile = 0;
+        logFile = nullptr;
     }
 }
 

--- a/tests/profile_conversationmodel/conversationmodelprofiletest.cpp
+++ b/tests/profile_conversationmodel/conversationmodelprofiletest.cpp
@@ -60,7 +60,7 @@ void ConversationModelProfileTest::prepare()
     QList<QPair<QString, QPair<QString, QString> > > contactDetails;
 
     int ci = remoteUids.count();
-    while(ci < contacts) {
+    while (ci < contacts) {
         QString phoneNumber;
         do {
             phoneNumber = QString().setNum(qrand() % 10000000);
@@ -71,7 +71,7 @@ void ConversationModelProfileTest::prepare()
 
         contactDetails.append(qMakePair(QString("Test Contact %1").arg(ci), qMakePair(phoneNumber, QString())));
 
-        if(ci % commitBatchSize == 0 && ci < contacts) {
+        if (ci % commitBatchSize == 0 && ci < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "contacts (" << ci << "/" << contacts << ")";
             addTestContacts(contactDetails);
@@ -94,7 +94,7 @@ void ConversationModelProfileTest::prepare()
     GroupModel groupModel;
 
     int gi = 0;
-    while(gi < contacts) {
+    while (gi < contacts) {
         Group grp;
         grp.setLocalUid(RING_ACCOUNT);
         grp.setRecipients(RecipientList::fromPhoneNumbers(QStringList() << remoteUids.at(contactIndices.at(gi))));
@@ -103,7 +103,7 @@ void ConversationModelProfileTest::prepare()
         groupList << grp;
 
         gi++;
-        if(gi % commitBatchSize == 0 && gi < contacts) {
+        if (gi % commitBatchSize == 0 && gi < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "groups (" << gi << "/" << contacts << ")";
         }
@@ -119,7 +119,7 @@ void ConversationModelProfileTest::prepare()
     QList<Event> eventList;
 
     int ei = 0;
-    while(ei < messages) {
+    while (ei < messages) {
         ei++;
 
         Event::EventDirection direction;
@@ -141,7 +141,7 @@ void ConversationModelProfileTest::prepare()
 
         eventList << e;
 
-        if(ei % commitBatchSize == 0 && ei != messages) {
+        if (ei % commitBatchSize == 0 && ei != messages) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "messages (" << ei << "/" << messages << ")";
             QVERIFY(addModel.addEvents(eventList, false));
@@ -165,15 +165,15 @@ void ConversationModelProfileTest::execute()
     int iterations = 1;
 
     logFile = new QFile("libcommhistory-performance-test.log");
-    if(!logFile->open(QIODevice::Append)) {
+    if (!logFile->open(QIODevice::Append)) {
         qDebug() << "!!!! Failed to open log file !!!!";
-        logFile = 0;
+        logFile = nullptr;
     }
 
     QDateTime startTime = QDateTime::currentDateTime();
 
     qDebug() << Q_FUNC_INFO << "- Fetching messages." << iterations << "iterations";
-    for(int i = 0; i < iterations; i++) {
+    for (int i = 0; i < iterations; i++) {
 
         ConversationModel fetchModel;
         fetchModel.setResolveContacts(resolve ? EventModel::ResolveImmediately : EventModel::DoNotResolve);
@@ -212,7 +212,7 @@ void ConversationModelProfileTest::cleanupTestCase()
     if (logFile) {
         logFile->close();
         delete logFile;
-        logFile = 0;
+        logFile = nullptr;
     }
 }
 

--- a/tests/profile_groupmodel/groupmodelprofiletest.cpp
+++ b/tests/profile_groupmodel/groupmodelprofiletest.cpp
@@ -35,7 +35,7 @@ void GroupModelProfileTest::initTestCase()
 {
     initTestDatabase();
 
-    logFile = 0;
+    logFile = nullptr;
 
     qsrand( QDateTime::currentDateTime().toTime_t() );
 }
@@ -59,7 +59,7 @@ void GroupModelProfileTest::prepare()
     QList<QPair<QString, QPair<QString, QString> > > contactDetails;
 
     int ci = remoteUids.count();
-    while(ci < contacts) {
+    while (ci < contacts) {
         QString phoneNumber;
         do {
             phoneNumber = QString().setNum(qrand() % 10000000);
@@ -70,7 +70,7 @@ void GroupModelProfileTest::prepare()
 
         contactDetails.append(qMakePair(QString("Test Contact %1").arg(ci), qMakePair(phoneNumber, QString())));
 
-        if(ci % commitBatchSize == 0 && ci < contacts) {
+        if (ci % commitBatchSize == 0 && ci < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "contacts (" << ci << "/" << contacts << ")";
             addTestContacts(contactDetails);
@@ -93,7 +93,7 @@ void GroupModelProfileTest::prepare()
     GroupModel addModel;
 
     int gi = 0;
-    while(gi < groups) {
+    while (gi < groups) {
         Group grp;
         grp.setLocalUid(RING_ACCOUNT);
         grp.setRecipients(RecipientList::fromPhoneNumbers(QStringList() << remoteUids.at(contactIndices.at(gi))));
@@ -102,7 +102,7 @@ void GroupModelProfileTest::prepare()
         groupList << grp;
 
         gi++;
-        if(gi % commitBatchSize == 0 && gi < groups) {
+        if (gi % commitBatchSize == 0 && gi < groups) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "groups (" << gi << "/" << groups << ")";
         }
@@ -118,8 +118,8 @@ void GroupModelProfileTest::prepare()
     gi = 0;
     foreach (Group grp, groupList) {
         QList<Event> eventList;
-        for(int i = 0; i < messages; i++) {
 
+        for (int i = 0; i < messages; i++) {
             Event e;
             e.setType(Event::SMSEvent);
             e.setDirection(qrand() % 2 ? Event::Inbound : Event::Outbound);
@@ -152,16 +152,16 @@ void GroupModelProfileTest::execute()
     int iterations = 1;
 
     logFile = new QFile("libcommhistory-performance-test.log");
-    if(!logFile->open(QIODevice::Append)) {
+    if (!logFile->open(QIODevice::Append)) {
         qDebug() << "!!!! Failed to open log file !!!!";
-        logFile = 0;
+        logFile = nullptr;
     }
 
     QDateTime startTime = QDateTime::currentDateTime();
 
     qDebug() << Q_FUNC_INFO << "- Fetching groups." << iterations << "iterations";
-    for(int i = 0; i < iterations; i++) {
 
+    for (int i = 0; i < iterations; i++) {
         GroupModel fetchModel;
 
         GroupManager manager;
@@ -195,10 +195,10 @@ void GroupModelProfileTest::finalise()
 
 void GroupModelProfileTest::cleanupTestCase()
 {
-    if(logFile) {
+    if (logFile) {
         logFile->close();
         delete logFile;
-        logFile = 0;
+        logFile = nullptr;
     }
 }
 

--- a/tests/profile_recentcontactsmodel/recentcontactsmodelprofiletest.cpp
+++ b/tests/profile_recentcontactsmodel/recentcontactsmodelprofiletest.cpp
@@ -62,7 +62,7 @@ void RecentContactsModelProfileTest::prepare()
     QList<QPair<QString, QPair<QString, QString> > > contactDetails;
 
     int ci = remoteUids.count();
-    while(ci < contacts) {
+    while (ci < contacts) {
         QString phoneNumber;
         do {
             phoneNumber = QString().setNum(qrand() % 10000000);
@@ -73,7 +73,7 @@ void RecentContactsModelProfileTest::prepare()
 
         contactDetails.append(qMakePair(QString("Test Contact %1").arg(ci), qMakePair(phoneNumber, (ci <= groups ? ACCOUNT1 : QString()))));
 
-        if(ci % commitBatchSize == 0 && ci < contacts) {
+        if (ci % commitBatchSize == 0 && ci < contacts) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "contacts (" << ci << "/" << contacts << ")";
             addTestContacts(contactDetails);
@@ -93,7 +93,7 @@ void RecentContactsModelProfileTest::prepare()
     QList<Group> groupList;
 
     int gi = 0;
-    while(gi < groups) {
+    while (gi < groups) {
         Group grp;
         grp.setLocalUid(ACCOUNT1);
         grp.setRecipients(RecipientList::fromUids(ACCOUNT1, QStringList() << remoteUids.at(contactIndices.at(gi))));
@@ -102,7 +102,7 @@ void RecentContactsModelProfileTest::prepare()
         groupList << grp;
 
         gi++;
-        if(gi % commitBatchSize == 0 && gi < groups) {
+        if (gi % commitBatchSize == 0 && gi < groups) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "groups (" << gi << "/" << groups << ")";
         }
@@ -115,7 +115,7 @@ void RecentContactsModelProfileTest::prepare()
     QList<Event> eventList;
 
     int ei = 0;
-    while(ei < events) {
+    while (ei < events) {
         ei++;
 
         int idIndex = contactIndices.at(qrand() % contacts);
@@ -137,7 +137,7 @@ void RecentContactsModelProfileTest::prepare()
 
         eventList << e;
 
-        if(ei % commitBatchSize == 0 && ei != events) {
+        if (ei % commitBatchSize == 0 && ei != events) {
             qDebug() << Q_FUNC_INFO << "- adding" << commitBatchSize
                 << "events (" << ei << "/" << events << ")";
             QVERIFY(addModel.addEvents(eventList, false));
@@ -160,7 +160,7 @@ void RecentContactsModelProfileTest::execute()
     int iterations = 1;
 
     logFile = new QFile("libcommhistory-performance-test.log");
-    if(!logFile->open(QIODevice::Append)) {
+    if (!logFile->open(QIODevice::Append)) {
         qDebug() << "!!!! Failed to open log file !!!!";
         logFile = 0;
     }
@@ -168,8 +168,8 @@ void RecentContactsModelProfileTest::execute()
     QDateTime startTime = QDateTime::currentDateTime();
 
     qDebug() << Q_FUNC_INFO << "- Fetching events." << iterations << "iterations";
-    for(int i = 0; i < iterations; i++) {
 
+    for (int i = 0; i < iterations; i++) {
         RecentContactsModel fetchModel;
         fetchModel.setLimit(limit);
 
@@ -199,10 +199,10 @@ void RecentContactsModelProfileTest::finalise()
 
 void RecentContactsModelProfileTest::cleanupTestCase()
 {
-    if(logFile) {
+    if (logFile) {
         logFile->close();
         delete logFile;
-        logFile = 0;
+        logFile = nullptr;
     }
 }
 

--- a/tools/catcher.h
+++ b/tools/catcher.h
@@ -38,12 +38,16 @@ class Catcher : public QObject
 {
     Q_OBJECT
 public:
-    Catcher(CommHistory::EventModel *model) : ok(true), count(0), stop(false) {
+    Catcher(CommHistory::EventModel *model)
+        : ok(true), count(0), stop(false)
+    {
         connect(model, SIGNAL(eventsCommitted(QList<CommHistory::Event>,bool)),
                 this, SLOT(eventsCommittedSlot(QList<CommHistory::Event>,bool)));
     };
 
-    Catcher(CommHistory::GroupModel *model) : ok(true), count(0), stop(false) {
+    Catcher(CommHistory::GroupModel *model)
+        : ok(true), count(0), stop(false)
+    {
         connect((QObject*)model, SIGNAL(groupsCommitted(QList<int>,bool)),
                 this, SLOT(groupsCommittedSlot(QList<int>,bool)));
     };
@@ -54,8 +58,9 @@ public:
         stop = false;
     }
 
-    void waitCommit(int numEvents = 1) {
-        while(count < numEvents || (numEvents == 0 && !stop)) {
+    void waitCommit(int numEvents = 1)
+    {
+        while (count < numEvents || (numEvents == 0 && !stop)) {
             qDebug() << ".";
             QCoreApplication::instance()->processEvents(QEventLoop::WaitForMoreEvents);
         }
@@ -67,7 +72,8 @@ public:
     bool stop;
 
 public Q_SLOTS:
-    void eventsCommittedSlot(QList<CommHistory::Event> committedEvents, bool success) {
+    void eventsCommittedSlot(QList<CommHistory::Event> committedEvents, bool success)
+    {
         qDebug() << Q_FUNC_INFO;
         ok = success;
         events = committedEvents;
@@ -75,7 +81,8 @@ public Q_SLOTS:
         stop = true;
     };
 
-    void groupsCommittedSlot(QList<int> committedGroups, bool success) {
+    void groupsCommittedSlot(QList<int> committedGroups, bool success)
+    {
         Q_UNUSED(committedGroups);
 
         qDebug() << Q_FUNC_INFO;

--- a/tools/commhistory-tool.cpp
+++ b/tools/commhistory-tool.cpp
@@ -285,25 +285,22 @@ int doAdd(const QStringList &arguments, const QVariantMap &options)
         else
             e.setDirection(direction);
 
-        if (isMms)
-        {
+        if (isMms) {
             e.setType(Event::MMSEvent);
             e.setLocalUid(localUid);
             e.setSubject(mmsSubject[qrand() % numMmsSubjects]);
             e.setMessageToken(QUuid::createUuid().toString());
 
-            if(e.direction() == Event::Outbound || qrand() % 2 == 0)
-            {
-                if(qrand() % 2 == 0)
+            if (e.direction() == Event::Outbound || qrand() % 2 == 0) {
+                if (qrand() % 2 == 0)
                     e.setCcList(QStringList() << "111111" << "222222" << "iam@cc.list.com");
-                if(qrand() % 2 == 0)
+                if (qrand() % 2 == 0)
                     e.setBccList(QStringList() << "33333" << "44444" << "iam@bcc.list.com");
 
                 QList<MessagePart> parts;
 
                 bool smilAdded = false;
-                if (qrand() % 2 == 0)
-                {
+                if (qrand() % 2 == 0) {
                     MessagePart part1;
                     part1.setContentType("application/smil");
                     parts << part1;
@@ -313,8 +310,7 @@ int doAdd(const QStringList &arguments, const QVariantMap &options)
                 part2.setContentId("text_slide1");
                 part2.setContentType("text/plain");
                 parts << part2;
-                if (smilAdded || qrand() % 3 == 0)
-                {
+                if (smilAdded || qrand() % 3 == 0) {
                     MessagePart part3;
                     part3.setContentId("catphoto");
                     part3.setContentType("image/jpeg");
@@ -323,15 +319,11 @@ int doAdd(const QStringList &arguments, const QVariantMap &options)
                 }
                 e.setMessageParts(parts);
             }
-        }
-        else if (isSms)
-        {
+        } else if (isSms) {
             e.setType(Event::SMSEvent);
             e.setLocalUid(localUid);
             e.setMessageToken(QUuid::createUuid().toString());
-        }
-        else
-        {
+        } else {
             e.setType(Event::IMEvent);
             e.setLocalUid(localUid);
         }
@@ -368,11 +360,11 @@ int doAdd(const QStringList &arguments, const QVariantMap &options)
     return 0;
 }
 
-int doAddCall( const QStringList &arguments, const QVariantMap &options )
+int doAddCall(const QStringList &arguments, const QVariantMap &options)
 {
-    Q_UNUSED( options )
+    Q_UNUSED(options)
 
-    qsrand( QDateTime::currentDateTime().toTime_t() );
+    qsrand(QDateTime::currentDateTime().toTime_t());
 
     int count = 1;
     if (options.contains("-n")) {
@@ -391,11 +383,11 @@ int doAddCall( const QStringList &arguments, const QVariantMap &options )
     QList<Event> events;
     for (int i = 0; i < count; i++) {
         Event e;
-        e.setType( Event::CallEvent );
-        e.setStartTime( QDateTime::currentDateTime() );
-        e.setEndTime( QDateTime::currentDateTime() );
-        e.setLocalUid( localUid );
-        e.setGroupId( -1 );
+        e.setType(Event::CallEvent);
+        e.setStartTime(QDateTime::currentDateTime());
+        e.setEndTime(QDateTime::currentDateTime());
+        e.setLocalUid(localUid);
+        e.setGroupId(-1);
 
         int callType = -1;
         if (arguments.last() == "dialed") {
@@ -423,8 +415,8 @@ int doAddCall( const QStringList &arguments, const QVariantMap &options )
         } else {
             e.setRecipients(Recipient(localUid, remoteUids[0]));
         }
-        e.setDirection( direction );
-        e.setIsMissedCall( isMissed );
+        e.setDirection(direction);
+        e.setIsMissedCall(isMissed);
 
         events.append(e);
     }
@@ -447,13 +439,13 @@ int doAddVCard(const QStringList &arguments, const QVariantMap &options)
 
     bool conversionSuccess = false;
     int id = arguments.at(2).toInt(&conversionSuccess);
-    if(!conversionSuccess) {
+    if (!conversionSuccess) {
         qCritical() << "Invalid event id";
         return -1;
     }
     EventModel model;
     Event e;
-    if(!model.databaseIO().getEvent(id, e)) {
+    if (!model.databaseIO().getEvent(id, e)) {
         qCritical() << "Error getting event" << id;
         return -1;
     }
@@ -617,7 +609,7 @@ int doListGroups(const QStringList &arguments, const QVariantMap &options)
 
 int doListContact(const QStringList &arguments, const QVariantMap &options)
 {
-    Q_UNUSED( options );
+    Q_UNUSED(options);
 
     RecipientEventModel model;
 
@@ -647,24 +639,20 @@ int doListContact(const QStringList &arguments, const QVariantMap &options)
     return 0;
 }
 
-int doListCalls( const QStringList &arguments, const QVariantMap &options )
+int doListCalls(const QStringList &arguments, const QVariantMap &options)
 {
-    Q_UNUSED( options );
+    Q_UNUSED(options);
 
     CallModel::Sorting sorting = CallModel::SortByContact;
     CallModel::ContactResolveType resolve = CallModel::DoNotResolve;
 
-    if ( arguments.count() >= 3 )
-    {
-        if ( arguments.at( 2 ) == "bytime" )
-        {
+    if (arguments.count() >= 3 ) {
+        if (arguments.at(2) == "bytime") {
             sorting = CallModel::SortByTime;
         }
 
-        if ( arguments.count() == 4 )
-        {
-            if ( arguments.at( 3 ) == "resolve" )
-            {
+        if (arguments.count() == 4) {
+            if (arguments.at(3) == "resolve") {
                 resolve = CallModel::ResolveImmediately;
             }
         }
@@ -674,17 +662,15 @@ int doListCalls( const QStringList &arguments, const QVariantMap &options )
     model.setFilter(sorting);
     model.setResolveContacts(resolve);
     model.setQueryMode(resolve == CallModel::ResolveImmediately ? EventModel::AsyncQuery : EventModel::SyncQuery);
-    if ( !model.getEvents() )
-    {
+    if (!model.getEvents()) {
         qCritical() << "Error fetching events";
         return -1;
     }
-    if ( !model.isReady() ) {
+    if (!model.isReady()) {
         waitForReadiness(model);
     }
 
-    for ( int i = 0; i < model.rowCount(); i++ )
-    {
+    for (int i = 0; i < model.rowCount(); i++) {
         Event e = model.event(model.index(i, 0));
         printEvent(e);
     }
@@ -828,33 +814,22 @@ int doSetStatus(const QStringList &arguments, const QVariantMap &options)
     }
 
     Event::EventStatus status;
-    if ( arguments.count() == 4 && arguments.at( 3 ) == "sending" )
-    {
+    if (arguments.count() == 4 && arguments.at(3) == "sending") {
         status = Event::SendingStatus;
-    }
-    else if ( arguments.count() == 4 && arguments.at( 3 ) == "sent" )
-    {
+    } else if (arguments.count() == 4 && arguments.at(3) == "sent") {
         status = Event::SentStatus;
-    }
-    else if ( arguments.count() == 4 && arguments.at( 3 ) == "delivered" )
-    {
+    } else if (arguments.count() == 4 && arguments.at(3) == "delivered") {
         status = Event::DeliveredStatus;
-    }
-    else if ( arguments.count() == 4 && arguments.at( 3 ) == "temporarilyfailed" )
-    {
+    } else if (arguments.count() == 4 && arguments.at(3) == "temporarilyfailed") {
         status = Event::TemporarilyFailedStatus;
-    }
-    else if ( arguments.count() == 4 && arguments.at( 3 ) == "permanentlyfailed" )
-    {
+    } else if (arguments.count() == 4 && arguments.at(3) == "permanentlyfailed") {
         status = Event::PermanentlyFailedStatus;
-    }
-    else
-    {
+    } else {
         status = Event::UnknownStatus;
     }
 
     qDebug() << "Old status: " << event.status();
-    event.setStatus( status );
+    event.setStatus(status);
     qDebug() << "New status: " << event.status();
 
     Catcher c(&model);
@@ -1242,7 +1217,8 @@ int doJsonImport(const QStringList &arguments, const QVariantMap &options)
         if (type != Event::CallEvent) {
             groupCatcher.reset();
             if (!groupModel.addGroup(group)) {
-                qWarning() << "Error adding conversation" << groupCount << "( local" << group.localUid() << ", remote" << group.recipients().debugString() << ")";
+                qWarning() << "Error adding conversation" << groupCount << "( local" << group.localUid()
+                           << ", remote" << group.recipients().debugString() << ")";
                 ok = false;
                 continue;
             }
@@ -1349,7 +1325,7 @@ int main(int argc, char **argv)
         if (args.at(1) == "add" && args.count() > 3) {
             return doAdd(args, options);
         } else if (args.at(1) == "addcall" && args.count() >= 3) {
-            return doAddCall( args, options );
+            return doAddCall(args, options);
         } else if (args.at(1) == "addVCard") {
             return doAddVCard(args, options);
         } else if (args.at(1) == "addClass0") {
@@ -1378,7 +1354,7 @@ int main(int argc, char **argv)
                                           args.at(3) == "delivered" ||
                                           args.at(3) == "temporarilyfailed" ||
                                           args.at(3) == "permanentlyfailed"))) {
-            return doSetStatus( args, options );
+            return doSetStatus(args, options);
         } else if (args.at(1) == "delete" && args.count() > 2) {
             return doDelete(args, options);
         } else if (args.at(1) == "deletegroup" && args.count() > 2) {


### PR DESCRIPTION
Main commit

    Oversight back then over a decade ago when porting database to sqlite.
    In practice it has allowed any data but just converted number like
    content.
    
    Perhaps ideally there would be a migration of the data content, but
    evidently the integer has worked good enough. Assuming less risk of
    regressions if we just adjust this for new installations.

Included some cosmetic changes as usual.